### PR TITLE
Active Chats and Chat State

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "async": "^2.0.0-rc.2",
+    "lodash": "^4.11.1",
     "socket.io": "^1.4.5",
     "uuid": "^2.0.1"
   }

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -9,11 +9,16 @@ export class ChatList extends EventEmitter {
 
 	constructor( { customers, operators, timeout = 1000 } ) {
 		super()
+
+		// chat state management
 		this._chats = {}
 		this._pending = {}
 		this._abandoned = {}
 
+		// Default timeout for querying operator clients for information
 		this._timeout = timeout
+
+		// event and io for customer and operator connections
 		this.customers = customers
 		this.operators = operators
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -40,6 +40,9 @@ export default ( { customers, agents, operators } ) => {
 	.on( 'found', ( channel, operator ) => {
 		debug( 'found operator', channel.id, operator.id )
 	} )
+	.on( 'chat.status', ( status, chat ) => {
+		debug( 'chats status changed', status, chat.id )
+	} )
 
 	toAgents( customers, 'join', 'customer.join' )
 	toAgents( customers, 'leave', 'customer.leave' )
@@ -71,17 +74,5 @@ export default ( { customers, agents, operators } ) => {
 		// - customers
 		customers.emit( 'receive', { id: message.context }, assign( {}, { author_type: 'agent' }, message ) )
 	} )
-
-	// TODO: Operator message -> Customers
-	// toCustomers( operators, 'message', 'receive', ( chat, user, message ) => {
-	// 	debug( 'message context', chat.id )
-	// 	return [Object.assign( {}, { author_type: 'operator', context: chat.id }, message )]
-	// } )
-
-	// TODO: Operator message -> Agents
-	// toAgents( operators, 'message', 'receive', ( { id }, user, message ) => {
-	// 	debug( 'format agent message', message )
-	// 	return [ formatAgentMessage( 'operator', message.user.id, id, message ) ]
-	// } )
 }
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -37,6 +37,7 @@ const join = ( { socket, events, user, io } ) => {
 
 	socket.join( user_room, () => {
 		socket.emit( 'init', user )
+		events.emit( 'init', user )
 	} )
 
 	socket.on( 'message', ( chat_id, { id, text } ) => {

--- a/src/operator.js
+++ b/src/operator.js
@@ -2,7 +2,9 @@ import EventEmitter from 'events'
 import { onConnection, timestamp } from './util'
 import { parallel } from 'async'
 import { isEmpty } from 'lodash/lang'
-import { assign } from 'lodash/object'
+import { set, assign, values } from 'lodash/object'
+import { throttle } from 'lodash/function'
+import { map, forEach, reduce } from 'lodash/collection'
 
 const DEFAULT_TIMEOUT = 1000
 
@@ -21,39 +23,156 @@ const identityForUser = ( { id, displayName, avatarURL } ) => (
 	{ id, displayName, avatarURL }
 )
 
+const queryClients = ( io, room ) => new Promise( ( resolve, reject ) => {
+	io.in( room ).clients( ( error, clients ) => {
+		if ( error ) {
+			return reject( error )
+		}
+		resolve( clients )
+	} )
+} )
+
+const online = ( io ) => queryClients( io, 'online' )
+
+const queryAvailability = ( chat, clients, io ) => new Promise( ( resolve, reject ) => {
+	if ( isEmpty( clients ) ) {
+		return reject( new Error( 'no operators connected' ) )
+	}
+
+	parallel( clients.map( ( socket_id ) => ( complete ) => {
+		withTimeout( ( cancel ) => {
+			const socket = io.connected[socket_id]
+			socket.emit( 'available', chat, ( available ) => {
+				complete( null, assign( { socket }, available ) )
+				cancel()
+			} )
+		}, () => complete( null, { capacity: 0, load: 0 } ) )
+	} ), ( error, results ) => {
+		if ( error ) {
+			return reject( error )
+		}
+		resolve( results )
+	} )
+} )
+
+const pickAvailable = ( availability ) => new Promise( ( resolve, reject ) => {
+	const operator = availability
+	.filter( ( op ) => op.capacity - op.load > 0 )
+	.sort( ( a, b ) => {
+		const a_open = a.capacity - a.load
+		const b_open = b.capacity - b.load
+		if ( a_open === b_open ) return 0
+		return ( a_open > b_open ? -1 : 1 )
+	} )
+	.sort( ( a, b ) => {
+		if ( a.load === b.load ) {
+			return 0
+		}
+		return a.load < b.load ? -1 : 1
+	} )[0]
+
+	if ( !operator ) {
+		return reject( new Error( 'no operators available' ) )
+	}
+
+	if ( !operator.id ) {
+		return reject( new Error( 'invalid operator' ) )
+	}
+
+	resolve( operator )
+} )
+
+const queryOnline = ( io, timeout ) => online( io ).then( ( clients ) => new Promise( ( resolve, reject ) => {
+	parallel( map( clients, ( client_id ) => ( complete ) => {
+		const client = io.connected[client_id]
+		withTimeout( ( cancel ) => {
+			client.emit( 'identify', ( identity ) => {
+				cancel()
+				complete( null, identity )
+			} )
+		}, () => complete( null, null ), timeout )
+	} ), ( error, results ) => {
+		if ( error ) {
+			return reject( error )
+		}
+		resolve( results )
+	} )
+} ) )
+
+const reduceUniqueOperators = ( operators ) => values( reduce( operators, ( unique, operator ) => {
+	if ( isEmpty( operator ) ) {
+		return unique
+	}
+	return set( unique, operator.id, operator )
+}, {} ) )
+
+const all = ( ... fns ) => ( ... args ) => forEach( fns, ( fn ) => fn( ... args ) )
+
+const emitOnline = throttle( ( io ) => {
+	// when a socket disconnects, query the online room for connected operators
+	queryOnline( io ).then( ( identities ) => {
+		debug( 'emitOnline called', identities )
+		io.emit( 'operators.online', reduceUniqueOperators( identities ) )
+	} )
+	.catch( ( e ) => debug( 'failed to query online', e ) )
+}, 100 )
+
 const join = ( { socket, events, user, io } ) => {
-	// TODO: initialize the agent
 	const user_room = `operators/${user.id}`
 	debug( 'initialize the operator', user )
+
 	socket.on( 'status', ( status, done ) => {
-		debug( 'set operator status', status )
+		// TODO: if operator has multiple clients, move all of them?
 		if ( status === 'online' ) {
 			debug( 'joining room', 'online' )
-			socket.join( 'online', done )
+			socket.join( 'online', all( done, () => emitOnline( io ) ) )
 		} else {
-			socket.leave( 'online', done )
+			socket.leave( 'online', all( done, () => emitOnline( io ) ) )
 		}
 	} )
 
+	socket.on( 'disconnect', () => emitOnline() )
+
 	socket.join( user_room, () => {
 		socket.emit( 'init', user )
-		events.emit( 'init', user )
+		events.emit( 'init', { user, socket, room: user_room } )
 	} )
 
 	socket.on( 'message', ( chat_id, { id, text } ) => {
 		const meta = {}
 		const userIdentity = identityForUser( user )
-		debug( 'Identify user', user )
 		const message = { id: id, text, timestamp: timestamp(), user: userIdentity, meta }
 		// all customer connections for this user receive the message
 		debug( 'broadcasting message', user.id, id, message )
 		events.emit( 'message', { id: chat_id }, user, message )
 	} )
-
-	socket.on( 'disconnect', () => {
-		debug( 'goodbye!', socket.rooms )
-	} )
 }
+
+const operatorClients = ( { io, operator } ) => new Promise( ( resolve, reject ) => {
+	const room = `operators/${ operator.id }`
+	io.in( room ).clients( ( error, clients ) => {
+		if ( error ) reject( error )
+		resolve( map( clients ), ( socketid ) => io.connected[socketid] )
+	} )
+} )
+
+const assignChat = ( { io, operator, chat, room } ) => new Promise( ( resolve, reject ) => {
+	const operator_room_name = `operators/${operator.id}`
+	// send the event to the operator and confirm that the chat was opened
+	// TODO: timeouts? only one should have to succeed or should all of them have to succeed?
+	operatorClients( { io, operator } )
+	.then( ( clients ) => {
+		parallel( clients.map( ( socketid ) => ( complete ) => {
+			io.connected[socketid].join( room, complete )
+		} ), ( e ) => {
+			if ( e ) {
+				reject( e )
+			}
+			io.in( operator_room_name ).emit( 'chat.open', chat )
+			resolve( operator )
+		} )
+	} )
+} )
 
 export default ( io ) => {
 	const events = new EventEmitter()
@@ -65,76 +184,28 @@ export default ( io ) => {
 		io.in( room_name ).emit( 'chat.message', { id }, message )
 	} )
 
-	events.on( 'assign', ( chat, callback ) => {
+	events.on( 'recover', ( { user }, chats, callback ) => {
+		parallel( map( chats, ( chat ) => ( complete ) => {
+			const room = `customers/${ chat.id }`
+			assignChat( { io, operator: user, chat, room } ).then( () => complete( null ), complete )
+		} ), ( e ) => {
+			if ( e ) {
+				debug( 'failed to recover chats', e )
+				return
+			}
+			callback()
+		} )
+	} )
+
+	events.on( 'assign', ( chat, room, callback ) => {
 		// find an operator
 		debug( 'find an operator for', chat.id )
-		const room_name = `customers/${ chat.id }`
-		io.in( 'online' ).clients( ( error, clients ) => {
-			if ( error ) {
-				return callback( error )
-			}
-			debug( 'online: ', clients.length )
-
-			const ifNotAvailable = () => callback( new Error( 'no clients available' ) )
-			// if there are no clients available emit error
-			if ( isEmpty( clients ) ) {
-				return ifNotAvailable()
-			}
-
-			// iterate each socket and see if there are any available?
-			parallel( clients.map( ( socket_id ) => ( complete ) => {
-				const socket = io.connected[socket_id]
-				debug( 'asking', socket_id )
-				withTimeout( ( cancel ) => {
-					socket.emit( 'available', chat, ( available ) => {
-						complete( null, assign( { socket }, available ) )
-						cancel()
-					} )
-				}, () => complete( null, { capacity: 0, load: 0 } ) )
-			} ), ( error, results ) => {
-				if ( error ) {
-					return ifNotAvailable()
-				}
-				if ( isEmpty( results ) ) {
-					return ifNotAvailable()
-				}
-
-				// pick the first socket with the most space and least load
-				const operator = results
-				.filter( ( op ) => op.capacity - op.load > 0 )
-				.sort( ( a, b ) => {
-					const a_open = a.capacity - a.load
-					const b_open = b.capacity - b.load
-					if ( a_open === b_open ) return 0
-					return ( a_open > b_open ? -1 : 1 )
-				} )
-				.sort( ( a, b ) => {
-					if ( a.load === b.load ) {
-						return 0
-					}
-					return a.load < b.load ? -1 : 1
-				} )[0]
-
-				if ( !operator ) {
-					return ifNotAvailable()
-				}
-
-				if ( !operator.id ) {
-					return ifNotAvailable()
-				}
-
-				const operator_room_name = `operators/${operator.id}`
-				// send the event to the operator and confirm that the chat was opened
-				io.in( operator_room_name ).clients( ( error, clients ) => {
-					parallel( clients.map( ( socketid ) => ( complete ) => {
-						io.connected[socketid].join( room_name, complete )
-					} ), ( e ) => {
-						io.in( operator_room_name ).emit( 'chat.open', chat )
-						callback( null, operator )
-					} )
-				} )
-			} )
-		} )
+		online( io )
+		.then( ( clients ) => queryAvailability( chat, clients, io ) )
+		.then( pickAvailable )
+		.then( ( operator ) => assignChat( { io, operator, chat, room } ) )
+		.then( ( operator ) => callback( null, operator ) )
+		.catch( callback )
 	} )
 
 	io.on( 'connection', ( socket ) => {

--- a/test/integration/abandon-test.js
+++ b/test/integration/abandon-test.js
@@ -1,0 +1,61 @@
+import { ok, equal } from 'assert'
+import util from './util'
+
+const debug = require( 'debug' )( 'tinkerchat:test:integration' )
+
+describe( 'Abandoned service', () => {
+	let mockUser = {
+		id: 'fake-user-id',
+		displayName: 'Nasuicaä',
+		username: 'nausicaa',
+		avatarURL: 'http://example.com/nausicaa'
+	}
+	let opUser = {
+		id: 'operator-id',
+		displayName: 'Ridley',
+		username: 'ridley',
+		avatarURL: 'http://sample.com/ridley'
+	}
+	let customerAuthenticator = ( socket, callback ) => callback( null, mockUser )
+	let agentAuthenticator = ( socket, callback ) => callback( null, {} )
+	let operatorAuthenticator = ( socket, callback ) => callback( null, opUser )
+
+	const service = util( { customerAuthenticator, agentAuthenticator, operatorAuthenticator } )
+
+	const setOperatorStatus = ( { operator, customer }, status = 'online' ) => new Promise( ( resolve ) => {
+		operator.emit( 'status', status, () => {
+			debug( `operator is ${ status }` )
+			resolve( { operator, customer } )
+		} )
+	} )
+
+	const assignOperator = ( { customer, operator } ) => new Promise( ( resolve ) => {
+		operator.once( 'available', ( chat, callback ) => {
+			callback( { capacity: 1, load: 0, id: opUser.id } )
+		} )
+		operator.once( 'chat.open', ( chat ) => {
+			resolve( { customer, operator, chat } )
+		} )
+		customer.emit( 'message', { text: 'help', id: 'message-1' } )
+	} )
+
+	const reconnectOperator = ( { operator } ) => new Promise( ( resolve ) => {
+		operator.once( 'disconnect', () => operator.connect() )
+		operator.once( 'chat.open', ( chat ) => {
+			resolve( chat )
+		} )
+		operator.disconnect()
+	} )
+
+	before( () => service.start() )
+	after( () => service.stop() )
+
+	it( 'recover abandoned chats', () => service.startClients()
+	.then( setOperatorStatus )
+	.then( assignOperator )
+	.then( reconnectOperator )
+	.then( ( chat ) => new Promise( ( resolve ) => {
+		equal( chat.id, 'fake-user-id' )
+		resolve()
+	} ) ) )
+} )

--- a/test/integration/service-test.js
+++ b/test/integration/service-test.js
@@ -1,12 +1,9 @@
-import { createServer } from 'http'
 import { equal } from 'assert'
-import service from '../../src/service'
-import IO from 'socket.io-client'
+import util from './util'
 
-const debug = require( 'debug' )( 'tinkerchat:test:integration' )
+const debug = require( 'debug' )( 'tinkerchat:test:service' )
 
 describe( 'Service', () => {
-	let server = createServer()
 	let mockUser = {
 		id: 'fake-user-id',
 		displayName: 'Nasuicaä',
@@ -19,57 +16,32 @@ describe( 'Service', () => {
 		username: 'furiosa',
 		avatarURL: 'http://example.com/furiousa'
 	}
-	let customerAuthenticator = ( socket, callback ) => {
-		debug( 'authorize client' )
-		callback( null, mockUser )
-	}
-	let agentAuthenticator = ( socket, callback ) => {
-		debug( 'authenticating agent' )
-		callback( null, {} )
-	}
-	let operatorAuthenticator = () => {
-	}
-	service( server, { customerAuthenticator, agentAuthenticator, operatorAuthenticator } )
+	let customerAuthenticator = ( socket, callback ) => callback( null, mockUser )
+	let agentAuthenticator = ( socket, callback ) => callback( null, botUser )
+	let operatorAuthenticator = ( socket, callback ) => callback( null, { id: 'operator-id' } )
 
-	const initClient = () => new Promise( ( resolve, reject ) => {
-		const client = new IO( 'http://localhost:61616/customer' )
-		client.once( 'init', () => resolve( client ) )
-		client.once( 'unauthorized', reject )
-	} )
+	const service = util( { customerAuthenticator, agentAuthenticator, operatorAuthenticator } )
 
-	const startAgent = () => new Promise( ( resolve, reject ) => {
-		const agent = new IO( 'http://localhost:61616/agent' )
-		agent.once( 'unauthorized', reject )
-		agent.once( 'init', () => resolve( agent ) )
-	} )
-
-	const initClientAndAgent = () => new Promise( ( resolve, reject ) => {
-		initClient().then( ( client ) => startAgent().then( ( agent ) => {
-			resolve( { client, agent } )
-		} ) )
-		.catch( reject )
-	} )
-
-	before( ( done ) => server.listen( 61616, done ) )
-	after( () => server.close() )
-
-	it( 'should allow agent to communicate with user', () => initClientAndAgent().then(
-		( { client, agent } ) => new Promise( ( resolve, reject ) => {
+	before( () => service.start() )
+	after( () => service.stop() )
+	it( 'should allow agent to communicate with user', () => service.startClients().then(
+		( { customer, agent } ) => new Promise( ( resolve ) => {
+			debug( 'time to test customer' )
 			agent.once( 'message', ( { context, text, id } ) => {
 				equal( id, 'message-1' )
 				agent.emit( 'message', { id: 'message-2', context, text: `re: ${text}`, user: botUser } )
 			} )
-			client.once( 'message', ( { id } ) => {
+			customer.once( 'message', ( { id } ) => {
 				equal( id, 'message-1' )
-				client.once( 'message', ( { id: next_id, text } ) => {
+				customer.once( 'message', ( { id: next_id, text } ) => {
 					equal( next_id, 'message-2' )
 					equal( text, 're: hello' )
-					client.close()
+					customer.close()
 					agent.close()
 					resolve()
 				} )
 			} )
-			client.emit( 'message', { text: 'hello', id: 'message-1' } )
+			customer.emit( 'message', { text: 'hello', id: 'message-1' } )
 		} )
 	) )
 } )

--- a/test/integration/service-test.js
+++ b/test/integration/service-test.js
@@ -36,6 +36,10 @@ describe( 'Service', () => {
 		server.listen( 61616, () => done() )
 	} )
 
+	after( () => {
+		server.close()
+	} )
+
 	it( 'should allow agent to communicate with user', ( done ) => {
 		const client = new IO( 'http://localhost:61616/customer' )
 		const startAgent = () => {

--- a/test/integration/util.js
+++ b/test/integration/util.js
@@ -1,0 +1,61 @@
+import { createServer } from 'http'
+import service from '../../src/service'
+import { assign } from 'lodash/object'
+
+import IO from 'socket.io-client'
+
+const debug = require( 'debug' )( 'tinkerchat:mock:service' )
+
+export const startServer = ( server, port ) => new Promise( ( resolve ) => {
+	server.listen( port, () => resolve() )
+} )
+
+export const stopServer = ( server ) => new Promise( ( resolve ) => {
+	// TODO: server.close callback is not working
+	server.close()
+	resolve()
+} )
+
+const startClient = ( port, namespace = '/' ) => new Promise( ( resolve, reject ) => {
+	const client = new IO( `http://localhost:${port}${namespace}` )
+
+	client.once( 'connect', () => debug( 'client is connecting ', namespace ) )
+	client.once( 'unauthorized', reject )
+	client.once( 'init', () => resolve( client ) )
+} )
+
+export const startCustomer = ( port ) => startClient( port, '/customer' )
+export const startAgent = ( port ) => startClient( port, '/agent' )
+export const startOperator = ( port ) => startClient( port, '/operator' )
+
+export const startClients = ( port ) => new Promise( ( resolve, reject ) => {
+	const clients = {}
+	startCustomer( port )
+	.then( ( customer ) => {
+		assign( clients, { customer } )
+		return startAgent( port )
+	} )
+	.then( ( agent ) => {
+		assign( clients, { agent } )
+		return startOperator( port )
+	} )
+	.then( ( operator ) => {
+		resolve( assign( clients, { operator } ) )
+	} )
+	.catch( reject )
+} )
+
+const main = ( authenticators, port = 65115 ) => {
+	let server = createServer()
+	service( server, authenticators )
+	return {
+		start: () => startServer( server, port ),
+		stop: () => stopServer( server ),
+		startClients: () => startClients( port ),
+		startCustomer: () => startCustomer( port ),
+		startAgent: () => startAgent( port ),
+		startOperator: () => startOperator( port )
+	}
+}
+
+export { main as default }

--- a/test/mock-io.js
+++ b/test/mock-io.js
@@ -1,9 +1,11 @@
 import { EventEmitter } from 'events'
 
-import { get, assign, keys } from 'lodash/object'
+import { get, assign } from 'lodash/object'
 
 const debug = require( 'debug' )( 'tinkerchat:mockio' )
 const noop = () => {}
+
+var COUNTER = 0
 
 export default ( socketid ) => {
 	const server = new EventEmitter()
@@ -41,7 +43,9 @@ export default ( socketid ) => {
 		process.nextTick( () => server.emit( 'connection', socket ) )
 	}
 
-	server.newClient = ( id = 'socket-io-id' ) => {
+	server.newClient = ( id ) => {
+		if ( id === undefined ) id = `socket-io-id-${ COUNTER }`
+		COUNTER ++
 		const client = new EventEmitter()
 		const socket = new EventEmitter()
 
@@ -67,7 +71,7 @@ export default ( socketid ) => {
 		return { socket, client }
 	}
 
-	server.connectNewClient = ( id = `socket-io-id ${ keys( server.connections ).count }`, next = noop ) => {
+	server.connectNewClient = ( id, next = noop ) => {
 		const connection = server.newClient( id )
 		const { socket } = connection
 		server.once( 'connection', next )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -24,7 +24,7 @@ describe( 'ChatList', () => {
 	beforeEach( () => {
 		operators = mockServer()
 		customers = mockServer()
-		chatlist = new ChatList( { operators, customers, timeout: 200 } )
+		chatlist = new ChatList( { operators, customers, timeout: 30 } )
 	} )
 
 	it( 'should notify when new chat has started', ( done ) => {

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -1,6 +1,7 @@
-import { ok, equal } from 'assert'
+import { ok, equal, deepEqual } from 'assert'
 import { EventEmitter } from 'events'
 import { isFunction, isArray } from 'lodash/lang'
+import { map } from 'lodash/collection'
 
 import { ChatList } from '../../src/chat-list'
 import { tick } from '../tick'
@@ -36,7 +37,7 @@ describe( 'ChatList', () => {
 	} )
 
 	it( 'should emit open request to operators', ( done ) => {
-		operators.on( 'assign', tick( ( { id }, callback ) => {
+		operators.on( 'assign', tick( ( { id }, name, callback ) => {
 			// chat is now pending an operator
 			ok( chatlist._pending['chat-id'] )
 			equal( id, 'chat-id' )
@@ -47,7 +48,7 @@ describe( 'ChatList', () => {
 	} )
 
 	it( 'should move chat to active when operator found', ( done ) => {
-		operators.on( 'assign', tick( ( _, callback ) => {
+		operators.on( 'assign', tick( ( { id }, name, callback ) => {
 			callback( null, { id: 'operator-id', socket: new EventEmitter() } )
 		} ) )
 		chatlist.on( 'found', tick( ( { id }, operator ) => {
@@ -69,9 +70,29 @@ describe( 'ChatList', () => {
 	} )
 
 	const assignOperator = ( operator_id, socket = new EventEmitter() ) => new Promise( ( resolve ) => {
-		operators.once( 'assign', ( _, callback ) => callback( null, { id: operator_id, socket } ) )
+		operators.once( 'assign', ( chat, room, callback ) => callback( null, { id: operator_id, socket } ) )
 		chatlist.once( 'found', () => resolve() )
 		emitCustomerMessage()
+	} )
+
+	describe( 'with customer connections', () => {
+		var socket
+		var operator_id = 'op'
+		beforeEach( () => {
+			// mock up some connected customer accounts
+			chatlist._pending = { abd: { id: 'abd', user: 'Pending' } }
+			chatlist._chats = { 123: { id: '123', user: 'Active' } }
+			chatlist._abandoned = { xyz: { id: 'xyz', user: 'Abandoned' } }
+			socket = new EventEmitter()
+		} )
+		it( 'should send operator list of active connections', ( done ) => {
+			socket.on( 'chats', tick( ( chats ) => {
+				equal( chats.length, 3 )
+				deepEqual( map( chats, ( { user } ) => user ), [ 'Active', 'Pending', 'Abandoned' ] )
+				done()
+			} ) )
+			operators.emit( 'init', { user: { id: operator_id }, socket } )
+		} )
 	} )
 
 	describe( 'with active chat', () => {
@@ -96,16 +117,19 @@ describe( 'ChatList', () => {
 			const abandoned = { operator: operator_id, channel: { id: chat_id } }
 			chatlist._abandoned = { 'chat-id': abandoned }
 
-			socket.on( 'chats', tick( ( chats, recovered ) => {
-				recovered()
+			operators.on( 'recover', tick( ( operator, chats, complete ) => {
+				complete()
+				ok( operator )
+				ok( operator.socket )
+				ok( operator.user )
 				ok( isArray( chats ) )
-				ok( isFunction( recovered ) )
+				ok( isFunction( complete ) )
 				equal( chats.length, 1 )
 				ok( !chatlist._abandoned[chat_id], 'chat still marked as abandoned' )
 				equal( chatlist._chats[chat_id], operator_id, 'chat not marked as an active chat' )
 				done()
 			} ) )
-			operators.emit( 'init', { id: operator_id, socket } )
+			operators.emit( 'init', { user: { id: operator_id }, socket } )
 		} )
 	} )
 } )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -1,22 +1,29 @@
 import { ok, equal } from 'assert'
 import { EventEmitter } from 'events'
-import { isFunction } from 'lodash/lang'
+import { isFunction, isArray } from 'lodash/lang'
 
 import { ChatList } from '../../src/chat-list'
 import { tick } from '../tick'
+import io from '../mock-io'
 
 // for breaking out of the promise chain so errors are thrown to mocha
+const mockServer = () => {
+	const server = new EventEmitter()
+	server.io = io().server
+	return server
+}
 
 describe( 'ChatList', () => {
 	let chatlist
 	let operators
 	let customers
-	let emitCustomerMessage = () => {
-		customers.emit( 'message', { id: 'chat-id' }, { text: 'hello' } )
+	const emitCustomerMessage = ( id = 'chat-id', text = 'hello' ) => {
+		customers.emit( 'message', { id }, { text } )
 	}
+
 	beforeEach( () => {
-		operators = new EventEmitter()
-		customers = new EventEmitter()
+		operators = mockServer()
+		customers = mockServer()
 		chatlist = new ChatList( { operators, customers, timeout: 200 } )
 	} )
 
@@ -59,5 +66,46 @@ describe( 'ChatList', () => {
 			done()
 		} ) )
 		emitCustomerMessage()
+	} )
+
+	const assignOperator = ( operator_id, socket = new EventEmitter() ) => new Promise( ( resolve ) => {
+		operators.once( 'assign', ( _, callback ) => callback( null, { id: operator_id, socket } ) )
+		chatlist.once( 'found', () => resolve() )
+		emitCustomerMessage()
+	} )
+
+	describe( 'with active chat', () => {
+		const operator_id = 'operator_id'
+		var socket = new EventEmitter()
+		beforeEach( () => assignOperator( operator_id, socket ) )
+
+		it( 'should mark chats as abandoned when their operator disconnects', () => {
+			socket.emit( 'disconnect' )
+			const abandoned = chatlist._abandoned['chat-id']
+			ok( abandoned, 'chat not marked as abandoned' )
+			equal( abandoned.operator, operator_id )
+			ok( socket )
+		} )
+	} )
+
+	describe( 'with abandoned chat', () => {
+		it( 'should reassign operator and make chats active', ( done ) => {
+			const operator_id = 'operator-id'
+			const chat_id = 'chat-id'
+			const socket = new EventEmitter()
+			const abandoned = { operator: operator_id, channel: { id: chat_id } }
+			chatlist._abandoned = { 'chat-id': abandoned }
+
+			socket.on( 'chats', tick( ( chats, recovered ) => {
+				recovered()
+				ok( isArray( chats ) )
+				ok( isFunction( recovered ) )
+				equal( chats.length, 1 )
+				ok( !chatlist._abandoned[chat_id], 'chat still marked as abandoned' )
+				equal( chatlist._chats[chat_id], operator_id, 'chat not marked as an active chat' )
+				done()
+			} ) )
+			operators.emit( 'init', { id: operator_id, socket } )
+		} )
 	} )
 } )

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -1,6 +1,9 @@
 import { ok, equal, deepEqual } from 'assert'
 import operator from '../../src/operator'
 import mockio from '../mock-io'
+import { tick } from '../tick'
+import { map } from 'lodash/collection'
+import { isEmpty } from 'lodash/lang'
 
 const debug = require( 'debug' )( 'tinkerchat:test:operators' )
 
@@ -9,32 +12,45 @@ describe( 'Operators', () => {
 	let socketid = 'socket-id'
 	let user
 	let socket, client, server
+
+	const connectOperator = ( { socket: useSocket, client: useClient }, authUser = { id: 'user-id', displayName: 'name' } ) => new Promise( ( resolve ) => {
+		debug( 'connect operator', authUser )
+		operators.once( 'connection', ( _, callback ) => callback( null, authUser ) )
+		useClient.once( 'init', ( clientUser ) => {
+			useClient.emit( 'status', 'online', () => resolve( clientUser ) )
+		} )
+		server.connect( useSocket )
+	} )
+
 	beforeEach( () => {
 		( { socket, client, server } = mockio( socketid ) )
 		operators = operator( server )
 	} )
 
 	describe( 'when authenticated and online', () => {
+		var op = { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var' }
 		beforeEach( ( done ) => {
-			operators.on( 'connection', ( _, callback ) => {
-				callback( null, { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var' } )
+			connectOperator( { socket, client }, op )
+			.then( ( operatorUser ) => {
+				user = operatorUser
+				done()
 			} )
-			client.once( 'init', ( clientUser ) => {
-				user = clientUser
-				client.emit( 'status', 'online', () => {
-					done()
-				} )
-			} )
-			server.connect( socket )
+		} )
+
+		it( 'should recover chats for an operator', ( done ) => {
+			operators.emit( 'recover', { user: op }, [ { id: 'something' } ], tick( () => {
+				equal( operators.io.rooms['customers/something'].length, 1 )
+				done()
+			} ) )
 		} )
 
 		it( 'should emit message', ( done ) => {
-			operators.on( 'message', ( { id: chat_id }, { id, displayName, avatarURL, priv }, { text, user } ) => {
+			operators.on( 'message', ( { id: chat_id }, { id, displayName, avatarURL, priv }, { text, user: author } ) => {
 				ok( id )
 				ok( displayName )
 				ok( avatarURL )
 				ok( priv )
-				ok( ! user.priv )
+				ok( ! author.priv )
 				equal( chat_id, 'chat-id' )
 				equal( text, 'message' )
 				done()
@@ -44,7 +60,10 @@ describe( 'Operators', () => {
 
 		it( 'should assign an operator to a new chat', ( done ) => {
 			// set up a second client
-			const { client: clientb } = server.connectNewClient( 'client-b', () => {
+			const connection = server.newClient()
+			const { client: clientb } = connection
+			connectOperator( connection, user )
+			.then( ( userb ) => {
 				let a_open = false, b_open = false;
 				client.on( 'chat.open', () => {
 					a_open = true
@@ -53,30 +72,55 @@ describe( 'Operators', () => {
 					b_open = true
 				} )
 
-				clientb.once( 'init', ( userb ) => {
-					clientb.emit( 'status', 'online', () => {
-						client.on( 'available', ( chat, callback ) => {
-							equal( chat.id, 'chat-id' )
-							callback( { load: 5, capacity: 6, id: user.id } )
-						} )
-						clientb.on( 'available', ( chat, callback ) => {
-							callback( { load: 5, capacity: 5, id: userb.id } )
-						} )
-						operators.emit( 'assign', { id: 'chat-id' }, ( error, op ) => {
-							ok( ! error )
-							ok( a_open )
-							ok( b_open )
-							ok( op.socket )
-							equal( op.id, 'user-id' )
-							done()
-						} )
-					} )
+				client.on( 'available', ( chat, callback ) => {
+					equal( chat.id, 'chat-id' )
+					callback( { load: 5, capacity: 6, id: user.id } )
+				} )
+				clientb.on( 'available', ( chat, callback ) => {
+					callback( { load: 5, capacity: 5, id: userb.id } )
+				} )
+				operators.emit( 'assign', { id: 'chat-id' }, 'room-name', ( error, assigned ) => {
+					ok( ! error )
+					ok( a_open )
+					ok( b_open )
+					ok( assigned.socket )
+					equal( assigned.id, 'user-id' )
+					done()
 				} )
 			} )
 		} )
+
+		it( 'should notify with updated operator list when operator joins', ( done ) => {
+			const userb = { id: 'a-user', displayName: 'Jem' }
+			const userc = { id: 'abcdefg', displayName: 'other' }
+			server.on( 'operators.online', tick( ( identities ) => {
+				equal( identities.length, 3 )
+				deepEqual( map( identities, ( { displayName } ) => displayName ), [ 'furiosa', 'Jem', 'other' ] )
+				done()
+			} ) )
+
+			const connectiona = server.newClient()
+			const connectionb = server.newClient()
+			const connectionc = server.newClient()
+
+			client.on( 'identify', ( callback ) => callback( user ) )
+			connectiona.client.on( 'identify', ( callback ) => callback( userb ) )
+			connectionb.client.on( 'identify', ( callback ) => callback( user ) )
+			connectionc.client.on( 'identify', ( callback ) => callback( userc ) )
+			connectOperator( connectiona, userb )
+			.then( () => connectOperator( connectionb, user ) )
+			.then( () => connectOperator( connectionc, userc ) )
+		} )
 	} )
 
-	it( 'should fail', () => {
-		ok( operators )
+	it( 'should send init message to events', ( done ) => {
+		operators.on( 'init', ( { user: u, socket: s, room } ) => {
+			ok( u )
+			ok( s )
+			ok( room )
+			equal( room, `operators/${u.id}` )
+			done()
+		} )
+		connectOperator( server.newClient(), { id: 'a-user' } ).catch( done )
 	} )
 } )


### PR DESCRIPTION
- [ ] When an operator connects they will be given a list of the existing active chats on the system. This includes the chats they are not assigned to.
- [x] When an operator reconnects they are 'reassigned' all of the active chats they abandoned. This chats are provided via a `chats` event emitted on the connecting socket and the client most call the callback to indicate that it has received the chats.
