### PR TITLE
Allow operators to include their status when identifying who is online

### DIFF
--- a/test/integration/operator-status-test.js
+++ b/test/integration/operator-status-test.js
@@ -1,0 +1,91 @@
+import { equal, deepEqual } from 'assert'
+import { series, parallel } from 'async'
+import { map } from 'lodash/collection'
+import util from './util'
+
+const debug = require( 'debug' )( 'tinkerchat:test:integration' )
+
+const noop = () => {}
+describe( 'Operator list', () => {
+	let operators = [
+		{ id: 'operator-1' },
+		{ id: 'operator-2' },
+		{ id: 'operator-3' },
+		{ id: 'operator-4' }
+	]
+
+	const service = util( {
+		operatorAuthenticator: ( ( users ) => ( socket, callback ) => {
+			const [user, ... rest] = users
+			debug( 'authenticating user', user )
+			callback( null, user )
+			users = rest
+		} )( operators ),
+		customerAuthenticator: noop,
+		agentAuthenticator: noop
+	} )
+
+	const waitForConnect = ( client ) => new Promise( ( resolve ) => {
+		debug( 'client is connecting' )
+		client.once( 'connect', () => {
+			debug( 'client connected' )
+			resolve( client )
+		} )
+	} )
+
+	before( () => service.start() )
+	after( () => service.stop() )
+
+	const connectAllOperators = () => new Promise( ( resolve ) => {
+		series( map( operators, ( operator ) => ( callback ) => {
+			service.startOperator()
+			.then( waitForConnect )
+			.then( ( client ) => {
+				client.on( 'identify', ( identify ) => identify( operator ) )
+				callback( null, client )
+			} )
+		} ), ( e, clients ) => {
+			resolve( clients )
+		} )
+	} )
+
+	const disconnectOperator = ( clients ) => new Promise( ( resolve ) => {
+		const [ client, ... rest ] = clients
+		client.on( 'disconnect', () => {
+			resolve( rest )
+		} )
+		client.close()
+	} )
+
+	const waitForList = ( clients ) => new Promise( ( resolve ) => {
+		parallel( map( clients, ( client ) => ( callback ) => {
+			client.once( 'operators.online', ( list ) => {
+				callback( null, list )
+			} )
+		} ), ( e, lists ) => {
+			resolve( { clients, lists } )
+		} )
+	} )
+
+	it( 'get updated operator lists', () => {
+		return connectAllOperators()
+		.then( waitForList )
+		.then( ( { clients, lists } ) => {
+			equal( lists.length, 4 )
+			deepEqual(
+				map( lists[0], ( { id } ) => id ),
+				map( operators, ( { id } ) => id )
+			)
+			return Promise.resolve( clients )
+		} )
+		.then( disconnectOperator )
+		.then( waitForList )
+		.then( ( { lists } ) => {
+			equal( lists.length, 3 )
+			deepEqual(
+				map( lists[0], ( { id } ) => id ),
+				map( operators.slice( 1 ), ( { id } ) => id )
+			)
+		} )
+	} )
+} )

--- a/test/mock-io.js
+++ b/test/mock-io.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 
-import { get, assign } from 'lodash/object'
+import { get, assign, keys } from 'lodash/object'
 import { forEach } from 'lodash/collection'
 
 const debug = require( 'debug' )( 'tinkerchat:test:mockio' )
@@ -36,6 +36,10 @@ export default ( socketid ) => {
 				return server
 			}
 		}
+	}
+
+	server.clients = ( cb ) => {
+		cb( null, keys( get( server, 'connected', {} ) ) )
 	}
 
 	server.connected = {}

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -29,7 +29,7 @@ describe( 'Operators', () => {
 	} )
 
 	describe( 'when authenticated and online', () => {
-		var op = { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var' }
+		var op = { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var', status: 'online' }
 		beforeEach( ( done ) => {
 			connectOperator( { socket, client }, op )
 			.then( ( { user: operatorUser } ) => {
@@ -134,11 +134,12 @@ describe( 'Operators', () => {
 		} )
 
 		it( 'should notify with updated operator list when operator joins', ( done ) => {
-			const userb = { id: 'a-user', displayName: 'Jem' }
-			const userc = { id: 'abcdefg', displayName: 'other' }
+			const userb = { id: 'a-user', displayName: 'Jem', status: 'online' }
+			const userc = { id: 'abcdefg', displayName: 'other', status: 'away' }
 			server.on( 'operators.online', tick( ( identities ) => {
 				equal( identities.length, 3 )
 				deepEqual( map( identities, ( { displayName } ) => displayName ), [ 'furiosa', 'Jem', 'other' ] )
+				deepEqual( map( identities, ( { status } ) => status ), [ 'online', 'online', 'away' ] )
 				done()
 			} ) )
 


### PR DESCRIPTION
When an operator connects or status changes the updated operator list is sent to all connected operators.

Originally only operators with the status of `online` would be included in this list, but now all connected operator clients are identified.

It is up to the client to provide its status when receiving the `identify` event.

Fixes #8 
