### PR TITLE
Fix parameter order for chat.transfer

### DIFF
--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -199,7 +199,7 @@ const join = ( { socket, events, user, io, selectIdentity } ) => {
 
 	socket.on( 'chat.transfer', ( chat_id, user_id ) => {
 		const toUser = selectIdentity( user_id )
-		events.emit( 'chat.transfer', user, chat_id, toUser )
+		events.emit( 'chat.transfer', chat_id, user, toUser )
 	} )
 }
 

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -139,7 +139,7 @@ describe( 'Operators', () => {
 				const connectionb = server.newClient()
 				return connectOperator( connectionb, userb )
 				.then( () => new Promise( resolve => {
-					operators.once( 'chat.transfer', ( opUser, chat_id, toUser ) => {
+					operators.once( 'chat.transfer', ( chat_id, opUser, toUser ) => {
 						equal( chat_id, chat.id )
 						deepEqual( opUser, op )
 						equal( toUser, userb )


### PR DESCRIPTION
should be => `chat, from, to` (previously being sent as `from, chat, to`)

Was causing all transfer requests to fail.
