### PR TITLE
Include operator status in operator list

### DIFF
--- a/src/operator/store.js
+++ b/src/operator/store.js
@@ -17,6 +17,7 @@ export const selectUser = ( { identities }, userId ) => get( identities, userId 
 const UPDATE_IDENTITY = 'UPDATE_IDENTITY'
 const REMOVE_USER = 'REMOVE_USER'
 const REMOVE_USER_SOCKET = 'REMOVE_USER_SOCKET'
+const UPDATE_USER_STATUS = 'UPDATE_USER_STATUS'
 
 export const updateIdentity = ( socket, user ) => {
 	return { socket, user, type: UPDATE_IDENTITY }
@@ -28,6 +29,10 @@ export const removeUser = user => {
 
 export const removeUserSocket = ( socket, user ) => {
 	return { user, socket, type: REMOVE_USER_SOCKET }
+}
+
+export const updateUserStatus = ( user, status ) => {
+	return { user, status, type: UPDATE_USER_STATUS }
 }
 
 const user_sockets = ( state = {}, action ) => {
@@ -53,6 +58,10 @@ const identities = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case UPDATE_IDENTITY:
 			return assign( {}, state, set( {}, user.id, user ) )
+		case UPDATE_USER_STATUS:
+			const { status } = action
+			const updated = assign( {}, get( state, user.id ), { status } )
+			return assign( {}, state, set( {}, user.id, updated ) );
 		case REMOVE_USER:
 			return omit( state, user.id )
 		default:

--- a/test/mock-io.js
+++ b/test/mock-io.js
@@ -75,6 +75,14 @@ export default ( socketid ) => {
 			server.rooms = assign( {}, server.rooms, newSockets )
 			process.nextTick( complete )
 		}
+		socket.leave = ( room, complete ) => {
+			socket.rooms = reject( socket.rooms, room )
+			const newSockets = {}
+			newSockets[room] = reject( get( server.rooms, room, [] ), socket )
+			debug( 'room now at', room, newSockets[room].length )
+			server.rooms = assign( {}, server.rooms, newSockets )
+			process.nextTick( complete )
+		}
 		socket.close = () => {}
 		return { socket, client }
 	}

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -17,7 +17,7 @@ describe( 'Operators', () => {
 		useClient.on( 'identify', ( identify ) => identify( authUser ) )
 		operators.once( 'connection', ( _, callback ) => callback( null, authUser ) )
 		useClient.once( 'init', ( clientUser ) => {
-			useClient.emit( 'status', 'online', () => resolve( { user: clientUser, client: useClient, socket: useSocket } ) )
+			useClient.emit( 'status', clientUser.status || 'online', () => resolve( { user: clientUser, client: useClient, socket: useSocket } ) )
 		} )
 		server.connect( useSocket )
 	} )
@@ -142,7 +142,7 @@ describe( 'Operators', () => {
 					operators.once( 'chat.transfer', ( chat_id, opUser, toUser ) => {
 						equal( chat_id, chat.id )
 						deepEqual( opUser, op )
-						equal( toUser, userb )
+						deepEqual( toUser, userb )
 						resolve()
 					} )
 					client.emit( 'chat.transfer', chat.id, userb.id )


### PR DESCRIPTION
When an operator's status changes update their status in the operator list.

When the operator list is updated it is sent to all connected operators. The status is included as the `status` key of the operator list in the `operators.online` event:

``` js
socket.on( 'operators.online', ( operators ) => {
   console.log( operators[0].status ); // first operator's status
} );
```
