### PR TITLE
Additional event_type meta and assign chat message

### DIFF
--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -226,7 +226,7 @@ export class ChatList extends EventEmitter {
 				} ) )
 			} )
 			.catch( ( assignmentError ) => {
-				debug( 'failed to find operator', assignmentError )
+				debug( 'failed to find operator', assignmentError, channelIdentity )
 				this.setChatAsMissed( channelIdentity, assignmentError )
 			} )
 		} )

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -106,14 +106,14 @@ export class ChatList extends EventEmitter {
 						} ) )
 					} ), this._timeout )
 				} )
-				.then( ( op ) => this.setChatAsAssigned( chat, op ) )
-				.then( ( op ) => this.emit( 'transfer', chat, op ) )
-				.catch( ( e ) => {
+				.then( op => this.setChatAsAssigned( chat, op ) )
+				.then( op => this.emit( 'transfer', chat, op ) )
+				.catch( e => {
 					debug( 'failed to transfer chat', e, chat )
 					this.setChatAsMissed( chat, e )
 				} )
 			} )
-			.catch( ( e ) => debug( 'chat does not exist', e ) )
+			.catch( e => debug( 'chat does not exist', e ) )
 		} )
 
 		operators.on( 'chat.leave', ( chat_id, operator ) => {
@@ -125,7 +125,7 @@ export class ChatList extends EventEmitter {
 					meta: { operator, event_type: 'leave' }
 				} ) )
 			} )
-			.catch( ( e ) => debug( 'Chat does not exist', chat_id, e ) )
+			.catch( e => debug( 'Chat does not exist', chat_id, e ) )
 		} )
 
 		operators.on( 'chat.close', ( chat_id, operator ) => {
@@ -192,7 +192,7 @@ export class ChatList extends EventEmitter {
 		const { id } = channelIdentity
 		const room_name = `customers/${ id }`
 		this.findChat( channelIdentity )
-		.then( ( chat ) => new Promise( ( resolve, reject ) => {
+		.then( chat => new Promise( ( resolve, reject ) => {
 			// are there any operators in the room?
 			this.operators.io.in( room_name ).clients( ( e, clients ) => {
 				if ( e ) {
@@ -239,7 +239,7 @@ export class ChatList extends EventEmitter {
 
 	findChatById( id ) {
 		return this.findAllOpenChats()
-		.then( ( chats ) => new Promise( ( resolve, reject ) => {
+		.then( chats => new Promise( ( resolve, reject ) => {
 			const chat = find( chats, ( { id: chat_id } ) => chat_id === id )
 			if ( chat ) {
 				return resolve( chat )

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -82,7 +82,7 @@ export class ChatList extends EventEmitter {
 				const room_name = `customers/${ chat.id }`
 				operators.emit( 'open', chat, room_name, operator )
 				operators.emit( 'message', chat, operator, assign( makeEventMessage( 'operator joined', chat.id ), {
-					meta: { operator }
+					meta: { operator, event_type: 'join' }
 				} ) )
 			} )
 			.catch( () => {
@@ -102,7 +102,7 @@ export class ChatList extends EventEmitter {
 					return promiseTimeout( new Promise( ( resolve, reject ) => {
 						operators.emit( 'transfer', chat, to, asCallback( resolve, reject ) )
 						operators.emit( 'message', chat, from, assign( makeEventMessage( 'chat transferred', chat.id ), {
-							meta: { from, to }
+							meta: { from, to, event_type: 'transfer' }
 						} ) )
 					} ), this._timeout )
 				} )
@@ -122,7 +122,7 @@ export class ChatList extends EventEmitter {
 				const room_name = `customers/${ chat.id }`
 				operators.emit( 'leave', chat, room_name, operator )
 				operators.emit( 'message', chat, operator, assign( makeEventMessage( 'operator left', chat.id ), {
-					meta: { operator }
+					meta: { operator, event_type: 'leave' }
 				} ) )
 			} )
 			.catch( ( e ) => debug( 'Chat does not exist', chat_id, e ) )

--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -144,9 +144,6 @@ const emitInChat = throttle( ( { io, chat } ) => {
 const join = ( { socket, events, user, io, selectIdentity } ) => {
 	debug( 'initialize the operator', user )
 	const user_room = `operators/${user.id}`
-
-	// emitOnline( { io, events } )
-
 	socket.on( 'status', ( status, done ) => {
 		// TODO: if operator has multiple clients, move all of them?
 		const updateStatus = ( e ) => {
@@ -185,7 +182,7 @@ const join = ( { socket, events, user, io, selectIdentity } ) => {
 	socket.on( 'message', ( chat_id, { id, text } ) => {
 		const meta = {}
 		const userIdentity = identityForUser( user )
-		const message = { id: id, session_id: chat_id, text,timestamp: timestamp(), user: userIdentity, meta }
+		const message = { id: id, session_id: chat_id, text, timestamp: timestamp(), user: userIdentity, meta }
 		// all customer connections for this user receive the message
 		debug( 'broadcasting message', user.id, id, message )
 		events.emit( 'message', { id: chat_id }, user, message )

--- a/test/integration/suggestion-test.js
+++ b/test/integration/suggestion-test.js
@@ -1,6 +1,9 @@
 import { deepEqual, ok } from 'assert'
 import util, { authenticators } from './util'
+import { tick } from '../tick'
 import find from 'lodash/find'
+import set from 'lodash/set'
+import every from 'lodash/every'
 
 const debug = require( 'debug' )( 'happychat:test:suggestion-test' )
 
@@ -14,9 +17,25 @@ describe( 'Chat logs', () => {
 	}
 
 	const afterInit = ( { customer, operator, agent } ) => new Promise( ( resolve ) => {
+		debug( 'setting up listeners after init' )
 		operator.on( 'available', ( _, available ) => available( { capacity: 1, load: 0 } ) )
 		operator.on( 'identify', callback => callback( { id: 'operator' } ) )
-		customer.on( 'init', () => resolve( { customer, operator, agent } ) )
+		const ready = { customer: false, operator: false, agent: false }
+		const resolveIfReady = () => {
+			if ( every( ready, value => value === true ) ) {
+				debug( 'clients initialized' )
+				resolve( { customer, operator, agent } )
+			}
+		}
+		const setReady = client => {
+			debug( 'setting client ready', client )
+			set( ready, client, true )
+			resolveIfReady()
+		}
+		customer.on( 'log', () => debug( 'received log' ) )
+		customer.on( 'init', () => setReady( 'customer' ) )
+		operator.on( 'init', () => setReady( 'operator' ) )
+		agent.on( 'init', () => setReady( 'agent' ) )
 	} )
 
 	const meta = {
@@ -25,6 +44,7 @@ describe( 'Chat logs', () => {
 
 	const replyToCustomerMessage = ( clients ) => new Promise( ( resolve ) => {
 		clients.agent.on( 'message', ( message ) => {
+			debug( 'replying to customers' )
 			const { session_id, text, author_type } = message
 			if ( author_type === 'agent' ) {
 				return
@@ -42,23 +62,32 @@ describe( 'Chat logs', () => {
 	} )
 
 	const setOperatorOnline = ( clients ) => new Promise( ( resolve ) => {
-		clients.operator.emit( 'status', 'online', () => resolve( clients ) )
+		debug( 'setting operator online' )
+		clients.operator.emit( 'status', 'online', () => {
+			debug( 'now online' )
+			resolve( clients )
+		} )
 	} )
 
 	const sendCustomerMessage = ( msg ) => ( clients ) => new Promise( resolve => {
-		clients.customer.emit( 'message', { id: ( new Date() ).getTime(), text: msg } )
+		debug( 'send customer message' )
+		tick( () => {
+			debug( 'emitting customer message' )
+			clients.customer.emit( 'message', { id: ( new Date() ).getTime(), text: msg } )
+		} )()
 		resolve( clients )
 	} )
 
 	const listenForSuggestion = clients => new Promise( resolve => {
 		// It could be in the log or received as the next message depending on
 		// how quickly the client connects
-
+		debug( 'listen for suggestion' )
 		clients.operator.once( 'log', ( _, log ) => {
 			const suggestion = find( log, ( { type } ) => type === 'elfbot' )
 			if ( suggestion ) resolve( suggestion )
 		} )
-		clients.operator.once( 'chat.message', ( chat, message ) => {
+		clients.operator.on( 'chat.message', ( chat, message ) => {
+			debug( 'received message' )
 			if ( message.type === 'elfbot' ) {
 				resolve( message )
 			}
@@ -66,7 +95,7 @@ describe( 'Chat logs', () => {
 	} )
 
 	beforeEach( () => {
-		service = util( authenticators( { id: 'customer' }, { id: 'operator' }, {} ) )
+		service = util( authenticators( { id: 'customer', session_id: 'customer-1', username: 'A-Customer' }, { id: 'operator' }, {} ) )
 		return service.start()
 	} )
 

--- a/test/integration/suggestion-test.js
+++ b/test/integration/suggestion-test.js
@@ -58,7 +58,11 @@ describe( 'Chat logs', () => {
 			const suggestion = find( log, ( { type } ) => type === 'elfbot' )
 			if ( suggestion ) resolve( suggestion )
 		} )
-		clients.operator.once( 'chat.message', ( chat, message ) => resolve( message ) )
+		clients.operator.once( 'chat.message', ( chat, message ) => {
+			if ( message.type === 'elfbot' ) {
+				resolve( message )
+			}
+		} )
 	} )
 
 	beforeEach( () => {

--- a/test/integration/transfer-test.js
+++ b/test/integration/transfer-test.js
@@ -63,7 +63,7 @@ describe( 'Operator Transfer', () => {
 			} ) )
 			.then( () => {
 				// check to make sure the transfer event message is in the log
-				let transfer = find( messages, ( { type } ) => type === 'event' )
+				let transfer = find( messages, ( { type, meta } ) => type === 'event' && meta.event_type === 'transfer' )
 				ok( transfer )
 				deepEqual( transfer.meta.from, operators[0] )
 				deepEqual( transfer.meta.to, operators[1] )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -192,6 +192,7 @@ describe( 'ChatList', () => {
 				equal( message.text, 'chat transferred' )
 				deepEqual( message.meta.to, newOperator )
 				deepEqual( message.meta.from, { id: operator_id } )
+				equal( message.meta.event_type, 'transfer' )
 				done()
 			} ) )
 			operators.emit( 'chat.transfer', chat.id, { id: operator_id }, newOperator )
@@ -203,6 +204,7 @@ describe( 'ChatList', () => {
 				equal( chat_id, chat.id )
 				ok( message.id )
 				deepEqual( message.meta.operator, newOperator )
+				equal( message.meta.event_type, 'join' )
 				done()
 			} ) )
 			operators.emit( 'chat.join', chat.id, newOperator )
@@ -213,6 +215,7 @@ describe( 'ChatList', () => {
 			operators.once( 'message', tick( ( { id: chat_id }, operator, message ) => {
 				equal( chat_id, chat.id )
 				deepEqual( message.meta.operator, newOperator )
+				equal( message.meta.event_type, 'leave' )
 				ok( message )
 				done()
 			} ) )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -21,6 +21,12 @@ describe( 'ChatList', () => {
 		customers.emit( 'message', { id }, { text } )
 	}
 
+	const autoAssign = operators => {
+		operators.on( 'assign', ( { id }, name, callback ) => {
+			callback( null, { id: 'operator-id', socket: new EventEmitter() } )
+		} )
+	}
+
 	beforeEach( () => {
 		operators = mockServer()
 		customers = mockServer()
@@ -57,6 +63,16 @@ describe( 'ChatList', () => {
 			equal( operator.id, 'operator-id' )
 			equal( chatlist._chats[id][0], 'assigned' )
 			deepEqual( chatlist._chats[id][2], operator )
+			done()
+		} ) )
+		emitCustomerMessage()
+	} )
+
+	it( 'should send chat event message when operator is found', done => {
+		autoAssign( operators )
+		operators.on( 'message', tick( ( { id: chat_id }, operator, message ) => {
+			equal( message.meta.event_type, 'assigned' )
+			deepEqual( message.meta.operator.id, 'operator-id' )
 			done()
 		} ) )
 		emitCustomerMessage()

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -54,7 +54,7 @@ describe( 'ChatList', () => {
 		emitCustomerMessage()
 	} )
 
-	it( 'should move chat to active when operator found', ( done ) => {
+	it( 'should move chat to active when operator found', done => {
 		operators.on( 'assign', tick( ( { id }, name, callback ) => {
 			callback( null, { id: 'operator-id', socket: new EventEmitter() } )
 		} ) )


### PR DESCRIPTION
Adds even_type meta to each chat event.

Now sends an event message when a chat is assigned to an operator.
