### PR TITLE
Fix user key mapping

### DIFF
--- a/src/customer.js
+++ b/src/customer.js
@@ -4,7 +4,7 @@ import { onConnection, timestamp } from './util'
 const debug = require( 'debug' )( 'happychat:customer' )
 
 // limit the information for the user
-const identityForUser = ( { id, displayName, avatarURL } ) => ( { id, displayName, avatarURL } )
+const identityForUser = ( { id, name, username, picture } ) => ( { id, name, username, picture } )
 
 /**
   - `user`: (**required**) a JSON key/value object containing:

--- a/test/unit/customer-test.js
+++ b/test/unit/customer-test.js
@@ -9,8 +9,8 @@ describe( 'Customer Service', () => {
 	const mockUser = {
 		id: 'abdefgh',
 		username: 'ridley',
-		displayName: 'Ridley',
-		avatarURL: 'http://example.com/image',
+		name: 'Ridley',
+		picture: 'http://example.com/image',
 		session_id: 'abdefgh-chat'
 	}
 	let auth
@@ -42,8 +42,9 @@ describe( 'Customer Service', () => {
 				ok( meta )
 				deepEqual( user, {
 					id: mockUser.id,
-					displayName: mockUser.displayName,
-					avatarURL: mockUser.avatarURL
+					name: mockUser.name,
+					username: mockUser.username,
+					picture: mockUser.picture
 				} )
 				done()
 			} )


### PR DESCRIPTION
The spec and happychat implementation return `displayName` as `name` instead, which means we end up with a nameless user object. Also include the username in the user identity object.
