### PR TITLE
Add `npm run test:coverage` command for test code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 lib/
 *.tgz
 .vscode
+coverage/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "`npm bin`/mocha --compilers js:babel-register --recursive",
+    "test:coverage": "babel-node `npm bin`/isparta cover --include-all-sources --include 'src/**/*.js' _mocha -- --recursive",
     "build": "`npm bin`/babel -d lib ./src/",
     "prepublish": "npm run build"
   },
@@ -22,6 +23,7 @@
     "babel-cli": "^6.5.2",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.0",
+    "isparta": "^4.0.0",
     "mocha": "^2.4.5"
   },
   "dependencies": {


### PR DESCRIPTION
Travis doesn't seem to have a built in way to publish the reports but it's handy to run locally. Current stats:

```
=============================== Coverage summary ===============================
Statements   : 96.08% ( 956/995 ), 27 ignored
Branches     : 86.5% ( 173/200 ), 34 ignored
Functions    : 95.67% ( 287/300 ), 1 ignored
Lines        : 94.33% ( 616/653 )
================================================================================
```
