### PR TITLE
Flag chat when a user disconnects

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -106,7 +106,7 @@ export default ( { customers, agents, operators } ) => {
 	} )
 
 	toAgents( customers, 'join', 'customer.join' )
-	toAgents( customers, 'leave', 'customer.leave' )
+	toAgents( customers, 'disconnect', 'customer.disconnect' ) // TODO: do we want to wait till timer triggers?
 
 	customers.on( 'join', ( socketIdentifier, user, socket ) => {
 		debug( 'emitting chat log' )

--- a/src/customer.js
+++ b/src/customer.js
@@ -6,6 +6,9 @@ const debug = require( 'debug' )( 'happychat:customer' )
 // limit the information for the user
 const identityForUser = ( { id, name, username, picture } ) => ( { id, name, username, picture } )
 
+const customerRoom = ( { session_id } ) => `session/${ session_id }`
+const chatRoom = ( { id } ) => `session/${ id }`
+
 /**
   - `user`: (**required**) a JSON key/value object containing:
     - `id`: (**required**) the unique identifier for this user in the *Support Provider*'s system
@@ -13,7 +16,7 @@ const identityForUser = ( { id, name, username, picture } ) => ( { id, name, use
     - `name`: (**required**) name to use in application UI
     - `picture`: (**required**) URL to image to display as user's avatar
     - `tags`: Array of strings to identify the user (example: `['premium', 'expired']`)
- */
+*/
 
 const init = ( { user, socket, events, io } ) => () => {
 	const socketIdentifier = { id: user.id, socket_id: socket.id, session_id: user.session_id }
@@ -36,17 +39,31 @@ const init = ( { user, socket, events, io } ) => () => {
 	} )
 
 	socket.on( 'typing', ( text ) => {
-		debug( 'received customer typing', user.id, text );
 		events.emit( 'typing', chat, user, text );
 	} )
 
-	socket.on( 'disconnect', () => events.emit( 'leave', socketIdentifier ) )
+	socket.on( 'disconnect', () => {
+		debug( 'socket.on.disconnect', user.id, socketIdentifier );
+
+		events.emit( 'disconnect-socket', { user, chat, socket } )
+
+		io.in( chatRoom( chat ) ).clients( ( error, clients ) => {
+			if ( error ) {
+				debug( 'failed to query customer clients', chat, error )
+				return;
+			}
+
+			if ( clients.length > 0 ) {
+				return;
+			}
+
+			events.emit( 'disconnect', chat, user )
+		} )
+	} )
+
 	socket.emit( 'init', user )
 	events.emit( 'join', socketIdentifier, chat, socket )
 }
-
-const customerRoom = ( { session_id } ) => `session/${ session_id }`
-const chatRoom = ( { id } ) => `session/${ id }`
 
 const join = ( { events, io, user, socket } ) => {
 	debug( 'user joined', user )

--- a/test/unit/controller-test.js
+++ b/test/unit/controller-test.js
@@ -28,14 +28,13 @@ describe( 'Controller', () => {
 		} )
 
 		it( 'notifies agent when user disconnects', ( done ) => {
-			agents.on( 'customer.leave', ( { id, socketId }, { id: user_id, displayName } ) => {
-				equal( id, 'user-id' )
-				equal( socketId, 'user-id' )
+			agents.on( 'customer.disconnect', ( { id: chat_id }, { id: user_id, displayName } ) => {
+				equal( chat_id, 'chat-id' )
 				equal( user_id, 'user-id' )
 				equal( displayName, 'Furiosa' )
 				done()
 			} )
-			customers.emit( 'leave', socketIdentifier, mockUser )
+			customers.emit( 'disconnect', { id: 'chat-id' }, mockUser )
 		} )
 	} )
 

--- a/test/unit/customer-test.js
+++ b/test/unit/customer-test.js
@@ -124,16 +124,25 @@ describe( 'Customer Service', () => {
 	it( 'should notify user join and leave', ( done ) => {
 		socket.id = 'socket-id'
 		let events = auth()
+
+		events.on( 'disconnect-socket', ( { socketIdentifier, chat, user } ) => {
+			equal( socketIdentifier.id, mockUser.id )
+			equal( socketIdentifier.socket_id, 'socket-id' )
+			equal( chat.user_id, mockUser.id )
+			equal( user.id, mockUser.id )
+		} )
+
+		events.on( 'disconnect', ( chat, user ) => {
+			equal( chat.user_id, mockUser.id )
+			equal( user.id, mockUser.id )
+			done()
+		} )
+
 		events.on( 'join', ( { id, socket_id } ) => {
 			equal( id, mockUser.id )
 			equal( socket_id, 'socket-id' )
 
-			events.on( 'leave', ( { id: left_id, socket_id: left_socket_id } ) => {
-				equal( left_id, mockUser.id )
-				equal( left_socket_id, 'socket-id' )
-				done()
-			} )
-			client.emit( 'disconnect' )
+			server.disconnect( { client, socket } )
 		} )
 	} )
 
@@ -141,5 +150,31 @@ describe( 'Customer Service', () => {
 		customer( server ).once( 'connection', ( _socket, authorize ) => authorize( new Error( 'nope' ) ) )
 		client.on( 'unauthorized', () => done() )
 		server.emit( 'connection', socket )
+	} )
+
+	describe( 'with multiple connections', () => {
+		let events, connection2;
+		beforeEach( () => {
+			events = auth()
+			connection2 = server.connectNewClient( 'socket-id2' )
+		} )
+
+		it( 'should not fire disconnect until all clients leave', ( done ) => {
+			const { socket: socket2, client: client2 } = connection2
+			events.once( 'disconnect', () => {
+				server.in( `session/${ mockUser.session_id }` ).clients( ( e, clients ) => {
+					equal( clients.length, 0 )
+					done()
+				} )
+			} )
+
+			events.once( 'join', () => {
+				server.in( `session/${ mockUser.session_id }` ).clients( ( e, clients ) => {
+					equal( clients.length, 2 )
+					server.disconnect( { client, socket } )
+					server.disconnect( { client: client2, socket: socket2 } )
+				} )
+			} )
+		} )
 	} )
 } )

--- a/test/unit/customer-test.js
+++ b/test/unit/customer-test.js
@@ -154,13 +154,13 @@ describe( 'Customer Service', () => {
 
 	describe( 'with multiple connections', () => {
 		let events, connection2;
-		beforeEach( () => {
-			events = auth()
-			connection2 = server.connectNewClient( 'socket-id2' )
+		beforeEach( ( next ) => {
+			events = auth( () => {
+				connection2 = server.connectNewClient( undefined, () => next() )
+			} )
 		} )
 
 		it( 'should not fire disconnect until all clients leave', ( done ) => {
-			const { socket: socket2, client: client2 } = connection2
 			events.once( 'disconnect', () => {
 				server.in( `session/${ mockUser.session_id }` ).clients( ( e, clients ) => {
 					equal( clients.length, 0 )
@@ -171,8 +171,9 @@ describe( 'Customer Service', () => {
 			events.once( 'join', () => {
 				server.in( `session/${ mockUser.session_id }` ).clients( ( e, clients ) => {
 					equal( clients.length, 2 )
+
 					server.disconnect( { client, socket } )
-					server.disconnect( { client: client2, socket: socket2 } )
+					server.disconnect( { client: connection2.client, socket: connection2.socket } )
 				} )
 			} )
 		} )


### PR DESCRIPTION
We change the status and start a timer and give them a grace period (120s) to return. If after that point, the user hasn't returned, send a message their operator letting them know that the user left so they can take necessary action.

We don't end the chat automatically and leave it on the operator to decide what to do at this point.

Fixes #51
