### PR TITLE
Customer capacity status

### DIFF
--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -224,7 +224,7 @@ export class ChatList extends EventEmitter {
 
 	onCustomerJoin( socketIdentifier, chat ) {
 		// find the chat
-		const notifyStatus = status => this.customers.emit( 'status', chat, status )
+		const notifyStatus = status => this.customers.emit( 'accept', chat, status )
 		this.findChat( chat )
 		.then(
 			() => {
@@ -235,7 +235,7 @@ export class ChatList extends EventEmitter {
 			() => {
 				debug( 'no chat for', chat )
 				promiseTimeout( new Promise( ( resolve, reject ) => {
-					this.operators.emit( 'status', chat, asCallback( resolve, reject ) )
+					this.operators.emit( 'accept', chat, asCallback( resolve, reject ) )
 				} ), this._timeout )
 				.then(
 					status => notifyStatus( status ),

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -26,7 +26,7 @@ const promiseTimeout = ( promise, ms = 1000 ) => new Promise( ( resolve, reject 
 		clear()
 		resolve( value )
 	}, ( error ) => {
-		clearTimeout( id )
+		clear()
 		reject( error );
 	} )
 } )

--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -9,13 +9,13 @@ import throttle from 'lodash/throttle'
 import map from 'lodash/map'
 import reduce from 'lodash/reduce'
 
-import {
-	default as reducer,
+import reducer, {
 	updateIdentity,
 	removeUser,
 	removeUserSocket,
 	selectIdentities,
 	selectSocketIdentity,
+	selectTotalCapacity,
 	selectUser,
 	updateUserStatus,
 	updateCapacity,
@@ -412,6 +412,12 @@ export default io => {
 			debug( 'failed to find operator', e )
 			callback( e )
 		} )
+	} )
+
+	// respond if operators are willing to handle new customer connection
+	events.on( 'accept', ( chat, callback ) => {
+		const { load, capacity } = 	selectTotalCapacity( store.getState() )
+		callback( null, capacity > load )
 	} )
 
 	io.on( 'connection', ( socket ) => {

--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -416,7 +416,7 @@ export default io => {
 
 	// respond if operators are willing to handle new customer connection
 	events.on( 'accept', ( chat, callback ) => {
-		const { load, capacity } = 	selectTotalCapacity( store.getState() )
+		const { load, capacity } = selectTotalCapacity( store.getState(), STATUS_AVAILABLE )
 		callback( null, capacity > load )
 	} )
 

--- a/src/operator/store.js
+++ b/src/operator/store.js
@@ -18,10 +18,10 @@ export const selectSocketIdentity = ( { sockets, identities }, socket ) => get(
 	get( sockets, socket.id )
 )
 export const selectUser = ( { identities }, userId ) => get( identities, userId )
-export const selectTotalCapacity = ( { identities } ) => reduce( identities,
-	( { load, capacity }, identity ) => ( {
-		load: load + identity.load,
-		capacity: capacity + identity.capacity
+export const selectTotalCapacity = ( { identities }, matchingStatus ) => reduce( identities,
+	( { load: totalLoad, capacity: totalCapacity }, { load, capacity, status } ) => ( {
+		load: totalLoad + ( status === matchingStatus ? load : 0 ),
+		capacity: totalCapacity + ( status === matchingStatus ? capacity : 0 )
 	} ),
 	{ load: 0, capacity: 0 }
 )

--- a/src/operator/store.js
+++ b/src/operator/store.js
@@ -6,6 +6,7 @@ import concat from 'lodash/concat'
 import values from 'lodash/values'
 import reject from 'lodash/reject'
 import omit from 'lodash/omit'
+import reduce from 'lodash/reduce'
 import { combineReducers } from 'redux'
 
 const debug = require( 'debug' )( 'happychat:operator:store' )
@@ -17,6 +18,13 @@ export const selectSocketIdentity = ( { sockets, identities }, socket ) => get(
 	get( sockets, socket.id )
 )
 export const selectUser = ( { identities }, userId ) => get( identities, userId )
+export const selectTotalCapacity = ( { identities } ) => reduce( identities,
+	( { load, capacity }, identity ) => ( {
+		load: load + identity.load,
+		capacity: capacity + identity.capacity
+	} ),
+	{ load: 0, capacity: 0 }
+)
 
 // Types
 const UPDATE_IDENTITY = 'UPDATE_IDENTITY'

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -23,8 +23,8 @@ describe( 'ChatList', () => {
 		customers.emit( 'message', { id }, { text } )
 	}
 
-	const autoAssign = operators => {
-		operators.on( 'assign', ( { id }, name, callback ) => {
+	const autoAssign = ops => {
+		ops.on( 'assign', ( { id }, name, callback ) => {
 			callback( null, { id: 'operator-id', socket: new EventEmitter() } )
 		} )
 	}
@@ -86,7 +86,7 @@ describe( 'ChatList', () => {
 		emitCustomerMessage()
 	} )
 
-	it( 'should timeout if no operator provided', () => new Promise( ( resolve ) => {
+	it( 'should timeout if no operator provided', () => new Promise( resolve => {
 		chatlist.on( 'miss', tick( ( error, { id } ) => {
 			equal( error.message, 'timeout' )
 			equal( id, 'chat-id' )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -98,14 +98,14 @@ describe( 'ChatList', () => {
 	it( 'should ask operators for status when customer joins', ( done ) => {
 		const socket = new EventEmitter();
 
-		operators.on( 'status', tick( ( chat, callback ) => {
+		operators.on( 'accept', tick( ( chat, callback ) => {
 			equal( chat.id, 'session-id' )
 			equal( typeof callback, 'function' )
 			// report that there is capacity
 			callback( null, true )
 		} ) )
 
-		customers.on( 'status', tick( ( chat, status ) => {
+		customers.on( 'accept', tick( ( chat, status ) => {
 			equal( chat.id, 'session-id' )
 			ok( status )
 			done()
@@ -115,11 +115,11 @@ describe( 'ChatList', () => {
 	} )
 
 	it( 'should fail status check if callback throws an error', done => {
-		operators.on( 'status', () => {
+		operators.on( 'accept', () => {
 			throw new Error( 'oops' )
 		} )
 
-		customers.on( 'status', tick( ( chat, status ) => {
+		customers.on( 'accept', tick( ( chat, status ) => {
 			equal( chat.id, 'session-id' )
 			ok( ! status )
 			done()
@@ -129,7 +129,7 @@ describe( 'ChatList', () => {
 	} )
 
 	it( 'should fail status check if callback times out', done => {
-		customers.on( 'status', tick( ( chat, status ) => {
+		customers.on( 'accept', tick( ( chat, status ) => {
 			equal( chat.id, 'session-id' )
 			ok( ! status )
 			done()

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -297,7 +297,7 @@ describe( 'Operators', () => {
 		} )
 	} )
 
-	describe( 'with multiple operators', () => {
+	describe( 'with multiple connected users', () => {
 		let ops = [
 			{ id: 'hermione', displayName: 'Hermione', avatarURL: 'url', status: 'available', capacity: 4, load: 1 },
 			{ id: 'ripley', displayName: 'Ripley', avatarURL: 'url', status: 'available', capacity: 1, load: 1 },
@@ -327,7 +327,7 @@ describe( 'Operators', () => {
 				let record = { socket: io.socket, client: io.client, operator: op, load: op.load, capacity: op.capacity, status: 'available' }
 				clients.push( record )
 				io.client.once( 'identify', identify => identify( op ) )
-				io.client.once( 'init', () => io.client.emit( 'status', 'online', () => resolve() ) )
+				io.client.once( 'init', () => io.client.emit( 'status', op.status, () => resolve() ) )
 				io.client.on( 'available', ( chat, callback ) => {
 					callback( { load: record.load, capacity: record.capacity, id: op.id, status: op.status } )
 				} )
@@ -379,7 +379,7 @@ describe( 'Operators', () => {
 			)
 		} ) )
 
-		it( 'should report operators accept customers', done => {
+		it( 'should report accepting customers', done => {
 			operators.emit( 'accept', { id: 'session-id' }, ( e, status ) => {
 				ok( status )
 				done();

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -29,6 +29,13 @@ describe( 'Operators', () => {
 		operators = operator( server )
 	} )
 
+	it( 'should report false status when no operators connected', done => {
+		operators.emit( 'accept', { id: 'session-id' }, ( e, status ) => {
+			ok( !status )
+			done()
+		} )
+	} )
+
 	describe( 'when authenticated and online', () => {
 		let op = { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var', status: 'online', load: 1, capacity: 3 }
 		beforeEach( ( done ) => {
@@ -370,7 +377,13 @@ describe( 'Operators', () => {
 					'river',    // 4/6 => 5/6
 				]
 			)
+		} ) )
+
+		it( 'should report operators accept customers', done => {
+			operators.emit( 'accept', { id: 'session-id' }, ( e, status ) => {
+				ok( status )
+				done();
+			} )
 		} )
-		)
 	} )
 } )


### PR DESCRIPTION
When a customer connection is initialize it should immediately be given a status.

We may want to do this even before the customer joins so we can respond quickly in the customer client when there isn't any operator capacity.
