### PR TITLE
Responds to accept with false when existing chat session is not assigned

### DIFF
--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -228,7 +228,13 @@ export class ChatList extends EventEmitter {
 		this.findChat( chat )
 		.then(
 			() => {
-				debug( 'already chatting', chat )
+				const status = this.getChatStatus( chat )
+				// user connected and their chat missed
+				if ( status !== STATUS_ASSIGNED ) {
+					notifyStatus( false )
+				} else {
+					debug( 'already chatting', chat )
+				}
 			},
 			// if there is no existing chat for this user
 			// query how many operators are available

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -138,6 +138,16 @@ describe( 'ChatList', () => {
 		customers.emit( 'join', { session_id: 'session-id' }, { id: 'session-id' } )
 	} )
 
+	it( 'should fail status check if existing chat is not assigned', ( done ) => {
+		chatlist._chats = { 'assigned-id': [ 'missed', { id: 'assigned-id' } ] }
+		customers.on( 'accept', tick( ( chat, status ) => {
+			equal( chat.id, 'assigned-id' )
+			ok( ! status )
+			done()
+		} ) )
+		customers.emit( 'join', { session_id: 'assigned-id' }, { id: 'assigned-id' } )
+	} )
+
 	const assignOperator = ( operator_id, socket = new EventEmitter() ) => new Promise( ( resolve ) => {
 		operators.once( 'assign', ( chat, room, callback ) => callback( null, { id: operator_id, socket } ) )
 		chatlist.once( 'found', () => resolve() )


### PR DESCRIPTION
If a user reconnects after chat is not accepted with the same session id, the chat does not receive an accept status.
