### PR TITLE
Making load-increment more granular

### DIFF
--- a/test/integration/transfer-test.js
+++ b/test/integration/transfer-test.js
@@ -65,8 +65,9 @@ describe( 'Operator Transfer', () => {
 				// check to make sure the transfer event message is in the log
 				let transfer = find( messages, ( { type, meta } ) => type === 'event' && meta.event_type === 'transfer' )
 				ok( transfer )
+				const expectedTo = Object.assign( {}, operators[1], { load: 1 } )
 				deepEqual( transfer.meta.from, operators[0] )
-				deepEqual( transfer.meta.to, operators[1] )
+				deepEqual( transfer.meta.to, expectedTo )
 			} )
 		} ) )
 	)


### PR DESCRIPTION
I'm trying to manually manage the operator load instead of on every assignment, because that was causing some double-counting.

Now we are manually incrementing the load on `assign`, `transfer`, and `recover`. Reloading the HUD was causing a `reassign` event and `recover` event, so it would double-increment (since both call `assignChat()`)
