### PR TITLE
Empty lib before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "NODE_PATH=./src `npm bin`/mocha --compilers js:babel-register --recursive",
     "test:watch": "npm test -- --watch -R min",
     "test:coverage": "NODE_PATH=./src babel-node `npm bin`/isparta cover --include-all-sources --include 'src/**/*.js' _mocha -- --recursive",
-    "build": "`npm bin`/babel -d lib ./src/",
+    "build": "rm -rf lib; `npm bin`/babel -d lib ./src/",
     "prepublish": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
To avoid sneaky bugs like old versions of files lying around
