### PR TITLE
Operator load is determined always by operators.online

### DIFF
--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -9,6 +9,7 @@ import find from 'lodash/find'
 import filter from 'lodash/filter'
 import reduce from 'lodash/reduce'
 import map from 'lodash/map'
+import isEmpty from 'lodash/isEmpty'
 import { makeEventMessage } from './util'
 
 const STATUS_PENDING = 'pending'
@@ -185,7 +186,11 @@ export class ChatList extends EventEmitter {
 		// if this is an additional there will be already assigned chats
 		// find them and open them on this socket
 		this.findOperatorChats( user )
-		.then( ( chats ) => {
+		.then( chats => {
+			if ( isEmpty( chats ) ) {
+				debug( 'no chats to reassign' )
+				return
+			}
 			debug( 'found existing chats, reassign:', user, chats )
 			this.operators.emit( 'reassign', user, socket, chats )
 		} )

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -352,9 +352,13 @@ export class ChatList extends EventEmitter {
 	}
 
 	findOperatorChats( operator ) {
-		return new Promise( ( resolve ) => {
-			resolve( map( filter( values( this._chats ), ( [ , , op ] ) => op.id === operator.id ), ( [, chat] ) => chat ) )
-		} )
+		debug( 'search for chats matching operator', this._chats )
+		return Promise.resolve(
+			map(
+				filter( values( this._chats ), ( [ , , op ] ) => op.id === operator.id ),
+				( [, chat] ) => chat
+			)
+		)
 	}
 
 	insertPendingChat( channelIdentity ) {

--- a/src/chat-list.js
+++ b/src/chat-list.js
@@ -187,10 +187,6 @@ export class ChatList extends EventEmitter {
 		// find them and open them on this socket
 		this.findOperatorChats( user )
 		.then( chats => {
-			if ( isEmpty( chats ) ) {
-				debug( 'no chats to reassign' )
-				return
-			}
 			debug( 'found existing chats, reassign:', user, chats )
 			this.operators.emit( 'reassign', user, socket, chats )
 		} )
@@ -355,7 +351,7 @@ export class ChatList extends EventEmitter {
 		debug( 'search for chats matching operator', this._chats )
 		return Promise.resolve(
 			map(
-				filter( values( this._chats ), ( [ , , op ] ) => op.id === operator.id ),
+				filter( values( this._chats ), ( [ , , op ] ) => op && op.id === operator.id ),
 				( [, chat] ) => chat
 			)
 		)

--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -377,7 +377,7 @@ export default io => {
 				debug( 'failed to recover chats', e )
 				return
 			}
-			store.dispatch( incrementLoad( user ) )
+			store.dispatch( incrementLoad( user, chats.length ) )
 			callback()
 		} )
 	} )

--- a/src/operator/store.js
+++ b/src/operator/store.js
@@ -57,8 +57,8 @@ export const updateCapacity = ( user, capacity ) => {
 	return { user, capacity, type: UPDATE_USER_CAPACITY }
 }
 
-export const incrementLoad = ( user ) => {
-	return { user, type: INCREMENT_USER_LOAD }
+export const incrementLoad = ( user, amount = 1 ) => {
+	return { user, type: INCREMENT_USER_LOAD, amount }
 }
 
 export const decrementLoad = ( user ) => {
@@ -127,7 +127,7 @@ const identities = ( state = {}, action ) => {
 		case UPDATE_AVAILABILITY:
 			return setOpAvailability( action.availability, state );
 		case INCREMENT_USER_LOAD:
-			const incrementedLoad = getLoad( user, state ) + 1;
+			const incrementedLoad = getLoad( user, state ) + action.amount;
 			return setLoad( { user, load: incrementedLoad }, state );
 		case DECREMENT_USER_LOAD:
 			const decrementCurrentLoad = getLoad( user, state ) - 1;


### PR DESCRIPTION
When recovering or reassigning multiple chants increment by the number of chats

Updates test to use `operators.online` to confirm correct load after a transfer.
