### PR TITLE
Allow transfer of unassigned chats

### DIFF
--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -262,16 +262,17 @@ const openChatForClients = ( { io, events, operator, room, chat } ) => ( clients
 	} )
 } )
 
-const assignChat = ( { io, operator, chat, room, events } ) => new Promise( ( resolve ) => {
+const assignChat = ( { io, operator, chat, room, events } ) => new Promise( ( resolve, reject ) => {
 	// send the event to the operator and confirm that the chat was opened
 	// TODO: timeouts? only one should have to succeed or should all of them have
 	// to succeed?
+	debug( 'assigning chat to operator')
 	operatorClients( { io, operator } )
 	.then( openChatForClients( { io, events, operator, room, chat } ) )
 	.then( () => {
 		emitInChat( { io, events, chat } )
 		resolve( operator )
-	} )
+	}, reject )
 } )
 
 const leaveChat = ( { io, operator, chat, room, events } ) => {

--- a/src/operator/index.js
+++ b/src/operator/index.js
@@ -339,17 +339,22 @@ export default io => {
 	} )
 
 	events.on( 'transfer', ( chat, from, to, complete ) => {
-		debug( 'transferring', chat, from, to );
-		const fromUser = selectUser( store.getState(), from.id )
+		debug( 'transferring', chat, from, to )
 		const toUser = selectUser( store.getState(), to.id )
 		const room = `customers/${ chat.id }`
 		// TODO: test for user availability
 		assignChat( { io, operator: toUser, chat, room, events } )
-		.then( () => {
-			store.dispatch( incrementLoad( toUser ) );
-			store.dispatch( decrementLoad( fromUser ) );
-			return complete( null, toUser.id )
-		} )
+		.then(
+			() => {
+				store.dispatch( incrementLoad( toUser ) );
+				if ( from ) {
+					const fromUser = selectUser( store.getState(), from.id )
+					store.dispatch( decrementLoad( fromUser ) );
+				}
+				return complete( null, toUser.id )
+			},
+			e => debug( 'failed to assign transfered chat', e )
+		)
 	} )
 
 	// additional operator socket came online

--- a/test/mock-io.js
+++ b/test/mock-io.js
@@ -34,7 +34,6 @@ export default ( socketid ) => {
 				return server
 			},
 			emit: ( ... args ) => {
-				// TODO: if any args blah
 				sockets.forEach( ( socket ) => socket.emit( ... args ) )
 				return server
 			}
@@ -71,7 +70,6 @@ export default ( socketid ) => {
 			socket.rooms = socket.rooms.concat( room )
 			const newSockets = {}
 			newSockets[room] = get( server.rooms, room, [] ).concat( socket )
-			debug( 'room now at', room, newSockets[room].length )
 			server.rooms = assign( {}, server.rooms, newSockets )
 			process.nextTick( complete )
 		}
@@ -79,7 +77,6 @@ export default ( socketid ) => {
 			socket.rooms = reject( socket.rooms, room )
 			const newSockets = {}
 			newSockets[room] = reject( get( server.rooms, room, [] ), socket )
-			debug( 'room now at', room, newSockets[room].length )
 			server.rooms = assign( {}, server.rooms, newSockets )
 			process.nextTick( complete )
 		}
@@ -96,9 +93,7 @@ export default ( socketid ) => {
 	}
 
 	server.disconnect = ( { socket, client } ) => {
-		debug( 'disconnect client and leave rooms', socket.id, client.id )
 		forEach( socket.rooms, ( room ) => {
-			debug( 'removing', socket.id, 'from', room, server.rooms[room] )
 			server.rooms[room] = reject( server.rooms[room], socket )
 		} )
 		socket.rooms = []

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -226,6 +226,17 @@ describe( 'Operators', () => {
 					} )
 					client.emit( 'chat.transfer', chat.id, users[0].id )
 				} )
+
+				it( 'should transfer when assigned is missing', done => {
+					operators.emit( 'transfer', chat, null, { id: users[0].id }, ( e, op_id ) => {
+						equal( e, null )
+						equal( op_id, users[0].id )
+					} )
+					connections[0].client.once( 'chat.open', ( _chat ) => {
+						deepEqual( _chat, chat )
+						done()
+					} )
+				} )
 			} )
 		} )
 

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -211,33 +211,35 @@ describe( 'Operators', () => {
 					{ id: 'ridley', displayName: 'ridley'}
 				]
 				let connections = []
-				beforeEach( () => users.reduce( ( promise, _user ) => {
-					let connection = server.newClient()
-					connections = connections.concat( connection )
-					return promise.then( () => connectOperator( connection, _user ) )
-				}, Promise.resolve() ) )
 
-				it( 'should transfer to user', ( done ) => {
+				const connectClients = () => Promise.all(
+					users.map( u => connectOperator( server.newClient(), u ) )
+				)
+
+				it( 'should transfer to user', () => connectClients().then( connections => new Promise( resolve => {
+					debug( 'fuck!' )
+					debug( 'doing it!', connections )
 					operators.once( 'chat.transfer', ( id, from, to ) => {
 						operators.emit( 'transfer', chat, from, to, () => {} )
 					} )
 					connections[0].client.once( 'chat.open', ( _chat ) => {
 						deepEqual( _chat, chat )
-						done()
+						resolve()
 					} )
 					client.emit( 'chat.transfer', chat.id, users[0].id )
-				} )
+				} ) ) )
 
-				it( 'should transfer when assigned is missing', done => {
+				it( 'should transfer when assigned is missing', () => connectClients().then( connections => new Promise( resolve => {
+					connections[0].client.on( 'chat.open', ( _chat ) => {
+						deepEqual( _chat, chat )
+						resolve()
+					} )
+
 					operators.emit( 'transfer', chat, null, { id: users[0].id }, ( e, op_id ) => {
 						equal( e, null )
 						equal( op_id, users[0].id )
 					} )
-					connections[0].client.once( 'chat.open', ( _chat ) => {
-						deepEqual( _chat, chat )
-						done()
-					} )
-				} )
+				} ) ) )
 			} )
 		} )
 

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -16,8 +16,8 @@ describe( 'Operators', () => {
 	let socket, client, server
 
 	const connectOperator = ( { socket: useSocket, client: useClient }, authUser = { id: 'user-id', displayName: 'name' } ) => new Promise( ( resolve ) => {
-		useClient.on( 'identify', ( identify ) => identify( authUser ) )
-		operators.once( 'connection', ( _, callback ) => callback( null, authUser ) )
+		useSocket.on( 'identify', ( identify ) => identify( null, authUser ) )
+		useClient.on( 'identify', ( identify ) => identify( null, authUser ) )
 		useClient.once( 'init', ( clientUser ) => {
 			useClient.emit( 'status', clientUser.status || 'online', () => resolve( { user: clientUser, client: useClient, socket: useSocket } ) )
 		} )
@@ -27,6 +27,7 @@ describe( 'Operators', () => {
 	beforeEach( () => {
 		( { socket, client, server } = mockio( socketid ) )
 		operators = operator( server )
+		operators.on( 'connection', ( s, callback ) => s.emit( 'identify', callback ) )
 	} )
 
 	it( 'should report false status when no operators connected', done => {


### PR DESCRIPTION
There are cases where chats become unassigned but still have operators in them. Those chats should be able to be transferred to other operators.
