### PR TITLE
Tests closing chat when action.chat_id is int

### DIFF
--- a/src/chat-list/reducer.js
+++ b/src/chat-list/reducer.js
@@ -10,7 +10,9 @@ import {
 	reduce,
 	when,
 	defaultTo,
-	lensIndex
+	lensIndex,
+	equals,
+	invoker
 } from 'ramda'
 import {
 	INSERT_PENDING_CHAT,
@@ -54,6 +56,15 @@ const setOperator = set( operatorLens )
 const setTimestamp = set( timestampLens )
 const setMembers = set( membersLens )
 
+const typeOf = v => typeof( v )
+const asString = when(
+	compose(
+		equals( 'number' ),
+		typeOf
+	),
+	invoker( 0, 'toString' )
+)
+
 const timestamp = () => ( new Date() ).getTime()
 
 const chat = ( state = [ null, null, null, null, {} ], action ) => {
@@ -79,7 +90,7 @@ const chat = ( state = [ null, null, null, null, {} ], action ) => {
 			return setStatus( STATUS_MISSED, state )
 		case OPERATOR_CHAT_LEAVE:
 		case REMOVE_USER:
-			return setMembers( dissoc( action.user.id, membersView( state ) ), state )
+			return setMembers( dissoc( asString( action.user.id ), membersView( state ) ), state )
 		case OPERATOR_CHAT_JOIN:
 			return setMembers( set( lensProp( action.user.id ), true, membersView( state ) ), state )
 		case OPERATOR_OPEN_CHAT_FOR_CLIENTS:
@@ -113,7 +124,7 @@ export default ( state = {}, action ) => {
 			const lens = lensProp( action.chat.id )
 			return set( lens, chat( view( lens, state ), action ) )( state )
 		case CLOSE_CHAT:
-			return dissoc( action.chat_id, state )
+			return dissoc( asString( action.chat_id ), state )
 		case SET_CHATS_RECOVERED:
 			return reduce(
 				( chats, chat_id ) => set(

--- a/test/unit/chat-list-reducer-test.js
+++ b/test/unit/chat-list-reducer-test.js
@@ -180,4 +180,12 @@ describe( 'ChatList reducer', () => {
 			3: [ STATUS_ABANDONED, '3', { id: 'op-id' }, 3, {} ],
 			4: [ STATUS_PENDING, '4', { id: 'other' }, 4, {} ]
 		}	) )
+
+	it( 'should close chat when id is int', dispatchAction(
+		closeChat( 451 ),
+		state => {
+			deepEqual( state, { chatlist: {} } )
+		},
+		{ 451: 'a chat' }
+	) )
 } )

--- a/test/unit/chat-list-reducer-test.js
+++ b/test/unit/chat-list-reducer-test.js
@@ -146,6 +146,15 @@ describe( 'ChatList reducer', () => {
 		{ id: [ 'open', { id: 'id' }, {}, 1, { user: true } ] }
 	) )
 
+	it( 'should remove operator as member with int id', dispatchAction(
+		operatorChatLeave( 'id', { id: 1 } ),
+		state => {
+			const [ , , , , members ] = state.chatlist.id
+			deepEqual( members, {} )
+		},
+		{ id: [ 'open', { id: 'id' }, {}, 1, { 1: true } ] }
+	) )
+
 	it( 'should set operator chats abandoned', dispatchAction(
 		setOperatorChatsAbandoned( 'op-id' ),
 		state => {


### PR DESCRIPTION
Ramda's object key manipulation requires keys to be strings, ints won't match.

```js
R.dissoc( 1, { 1: "one" } )
// => { "1": "one" }
R.dissoc( "1", { 1: "one" } )
// => {}
```

Or here's an example where `assoc` with int key and then `dissoc` with int key produces unexpected output:

```js
R.pipe(
  R.assoc( 1, 'a' ),
  R.dissoc( 1 )
)( {} )
// => { "1", "a" }
```