### PR TITLE
Reassign closed chats to operator that closed it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happychat-service",
-  "version": "0.10.8-0",
+  "version": "0.10.8-1",
   "description": "Socket.IO based chat server for happychat.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happychat-service",
-  "version": "0.10.7",
+  "version": "0.10.8-0",
   "description": "Socket.IO based chat server for happychat.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   },
   "homepage": "https://github.com/automattic/happychat-service#readme",
   "devDependencies": {
-    "babel-cli": "^6.5.2",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-register": "^6.7.0",
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.2",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-register": "^6.18.0",
     "isparta": "^4.0.0",
     "mocha": "^2.4.5",
     "mocha-junit-reporter": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happychat-service",
-  "version": "0.10.8-1",
+  "version": "0.10.8-2",
   "description": "Socket.IO based chat server for happychat.",
   "main": "index.js",
   "scripts": {

--- a/src/chat-list/reducer.js
+++ b/src/chat-list/reducer.js
@@ -37,6 +37,7 @@ export const STATUS_ASSIGNED = 'assigned'
 export const STATUS_ASSIGNING = 'assigning'
 export const STATUS_ABANDONED = 'abandoned'
 export const STATUS_CUSTOMER_DISCONNECT = 'customer-disconnect'
+export const STATUS_CLOSED = 'closed'
 
 const statusLens = lensIndex( 0 )
 const chatLens = lensIndex( 1 )
@@ -66,6 +67,8 @@ const chat = ( state = [ null, null, null, null, {} ], action ) => {
 				setTimestamp( timestamp() ),
 				setChat( action.chat )
 			)( state )
+		case CLOSE_CHAT:
+			return setStatus( STATUS_CLOSED, state );
 		case SET_CHAT_OPERATOR:
 		case SET_CHATS_RECOVERED:
 			return compose(
@@ -108,6 +111,7 @@ export default ( state = {}, action ) => {
 		case OPERATOR_CHAT_JOIN:
 		case OPERATOR_CHAT_LEAVE:
 		case SET_CHAT_CUSTOMER_DISCONNECT:
+		case CLOSE_CHAT:
 			const chatIdLens = lensProp( action.chat_id )
 			return set( chatIdLens, chat( view( chatIdLens, state ), action ) )( state )
 		case INSERT_PENDING_CHAT:
@@ -115,8 +119,6 @@ export default ( state = {}, action ) => {
 		case ASSIGN_CHAT:
 			const lens = lensProp( action.chat.id )
 			return set( lens, chat( view( lens, state ), action ) )( state )
-		case CLOSE_CHAT:
-			return dissoc( asString( action.chat_id ), state )
 		case SET_CHATS_RECOVERED:
 			return reduce(
 				( chats, chat_id ) => set(

--- a/src/chat-list/reducer.js
+++ b/src/chat-list/reducer.js
@@ -11,9 +11,8 @@ import {
 	when,
 	defaultTo,
 	lensIndex,
-	equals,
-	invoker
 } from 'ramda'
+import { asString } from '../util'
 import {
 	INSERT_PENDING_CHAT,
 	SET_CHAT_OPERATOR,
@@ -26,6 +25,7 @@ import {
 } from './actions'
 import {
 	OPERATOR_OPEN_CHAT_FOR_CLIENTS,
+	SET_USER_OFFLINE,
 	REMOVE_USER,
 	OPERATOR_CHAT_LEAVE,
 	OPERATOR_CHAT_JOIN,
@@ -56,15 +56,6 @@ const setOperator = set( operatorLens )
 const setTimestamp = set( timestampLens )
 const setMembers = set( membersLens )
 
-const typeOf = v => typeof( v )
-const asString = when(
-	compose(
-		equals( 'number' ),
-		typeOf
-	),
-	invoker( 0, 'toString' )
-)
-
 const timestamp = () => ( new Date() ).getTime()
 
 const chat = ( state = [ null, null, null, null, {} ], action ) => {
@@ -89,6 +80,7 @@ const chat = ( state = [ null, null, null, null, {} ], action ) => {
 		case SET_CHAT_MISSED:
 			return setStatus( STATUS_MISSED, state )
 		case OPERATOR_CHAT_LEAVE:
+		case SET_USER_OFFLINE:
 		case REMOVE_USER:
 			return setMembers( dissoc( asString( action.user.id ), membersView( state ) ), state )
 		case OPERATOR_CHAT_JOIN:
@@ -140,6 +132,7 @@ export default ( state = {}, action ) => {
 				whenOperatorIs( action.operator_id )( value => chat( value, action ) )
 			)( state )
 		case REMOVE_USER:
+		case SET_USER_OFFLINE:
 			return map( ( chatState ) => chat( chatState, action ), state )
 	}
 	return state

--- a/src/chat-list/selectors.js
+++ b/src/chat-list/selectors.js
@@ -10,7 +10,8 @@ import {
 	both,
 	defaultTo,
 	isEmpty,
-	head
+	head,
+	not
 } from 'ramda'
 import {
 	statusView,
@@ -21,14 +22,15 @@ import {
 	STATUS_MISSED,
 	STATUS_NEW,
 	STATUS_PENDING,
-	STATUS_ASSIGNING
+	STATUS_ASSIGNING,
+	STATUS_CLOSED
 } from './reducer'
 
 const selectChatlist = view( lensProp( 'chatlist' ) )
 const mapToChat = map( chatView )
 const mapToMembers = map( membersView )
 const matchingStatus = status => filter( compose( equals( status ), statusView ) )
-
+const filterClosed = compose( not, whereEq( { status: STATUS_CLOSED } ) )
 /*
 Selects all chats assigned/associated with given operator id
 */
@@ -49,6 +51,7 @@ export const getChatsForOperator = ( operator_id, state ) => compose(
 )( state )
 
 export const getChatMembers = compose( mapToMembers, values, selectChatlist )
+export const getOpenChatMembers = compose( mapToMembers, filterClosed, values, selectChatlist )
 export const getAllChats = compose( mapToChat, values, selectChatlist )
 export const getChatsWithStatus = ( status, state ) => compose(
 	mapToChat,
@@ -97,7 +100,13 @@ export const getChatStatus = ( chat_id, state ) => defaultTo( STATUS_NEW )( comp
 	selectChatlist
 )( state ) )
 
-export const isChatStatusNew = ( chat_id, state ) => equals( STATUS_NEW, getChatStatus( chat_id, state ) )
+export const isChatStatusNew = ( chat_id, state ) => equals(
+	STATUS_NEW, getChatStatus( chat_id, state )
+)
+
+export const isChatStatusClosed = ( chat_id, state ) => equals(
+	STATUS_CLOSED, getChatStatus( chat_id, state )
+)
 
 export const haveChatWithStatus = ( status, state ) => ! isEmpty(
 	getChatsWithStatus( status, state )

--- a/src/middlewares/socket-io/chatlist.js
+++ b/src/middlewares/socket-io/chatlist.js
@@ -59,6 +59,7 @@ import {
 } from '../../chat-list/reducer'
 import {
 	REMOVE_USER,
+	SET_USER_OFFLINE,
 	OPERATOR_CHAT_LEAVE,
 	OPERATOR_READY,
 	OPERATOR_CHAT_JOIN,
@@ -453,7 +454,7 @@ export default ( { io, timeout = 1000, customerDisconnectTimeout = 90000 }, cust
 				customer_io.emit( 'accept', action.enabled )
 				break;
 			case NOTIFY_CHAT_STATUS_CHANGED:
-				debug( 'NOTIFY_CHAT_STATUS_CHANGED', action.chat_id )
+				debug( 'NOTIFY_CHAT_STATUS_CHANGED', action.chat_id, action.status, action.lastStatus )
 				const status = getChatStatus( action.chat_id, store.getState() );
 				customer_io.to( customerRoom( action.chat_id ) ).emit( 'status', status )
 				break;
@@ -476,6 +477,7 @@ export default ( { io, timeout = 1000, customerDisconnectTimeout = 90000 }, cust
 				handleOperatorReady( action )
 				return next( action )
 			case REMOVE_USER:
+			case SET_USER_OFFLINE:
 				handleOperatorDisconnect( action )
 				return next( action )
 			case CUSTOMER_INBOUND_MESSAGE:

--- a/src/middlewares/socket-io/index.js
+++ b/src/middlewares/socket-io/index.js
@@ -10,7 +10,7 @@ import {
 	updateUserStatus,
 	updateCapacity,
 	removeUserSocket,
-	removeUser,
+	setUserOffline,
 	updateIdentity,
 	operatorTyping,
 	operatorChatJoin,
@@ -60,14 +60,14 @@ const join = ( { socket, store, user, io } ) => {
 			if ( clients.length > 0 ) {
 				return;
 			}
-			store.dispatch( removeUser( user ) )
+			store.dispatch( setUserOffline( user ) )
 		} )
 	} )
 
 	socket.join( user_room, () => {
-		socket.emit( 'init', user )
 		store.dispatch( updateIdentity( socket, user ) )
 		store.dispatch( operatorReady( user, socket, user_room ) )
+		socket.emit( 'init', user )
 	} )
 
 	socket.on( 'message', ( chat_id, { id, text } ) => {

--- a/src/middlewares/socket-io/operator-load.js
+++ b/src/middlewares/socket-io/operator-load.js
@@ -20,7 +20,8 @@ import {
 	OPERATOR_CHAT_JOIN,
 	SET_USER_LOADS,
 	OPERATOR_OPEN_CHAT_FOR_CLIENTS,
-	REMOVE_USER
+	REMOVE_USER,
+	SET_USER_OFFLINE
 } from '../../operator/actions'
 import { REMOTE_ACTION_TYPE } from './broadcast'
 import {
@@ -87,6 +88,7 @@ const updateLoadMiddleware = ( { getState, dispatch } ) => next => action => {
 		case SET_CHAT_OPERATOR:
 		case SET_CHATS_RECOVERED:
 		case REMOVE_USER:
+		case SET_USER_OFFLINE:
 			const result = next( action )
 			dispatch( setUserLoads( reducer( getState() ) ) )
 			return result;

--- a/src/middlewares/socket-io/operator-load.js
+++ b/src/middlewares/socket-io/operator-load.js
@@ -1,4 +1,4 @@
-import { getChatMembers, getChatsForOperator, getChatStatus } from '../../chat-list/selectors';
+import { getOpenChatMembers, getChatsForOperator, getChatStatus } from '../../chat-list/selectors';
 import {
 	assignNextChat,
 	notifySystemStatusChange,
@@ -50,7 +50,7 @@ const sumMemberships = ( total, members ) => evolve(
 	// merge total into members to fill any keys that aren't present
 	merge( members, total )
 )
-const reducer = compose( reduce( sumMemberships, {} ), getChatMembers )
+const reducer = compose( reduce( sumMemberships, {} ), getOpenChatMembers )
 
 const handleSetUserLoads = ( { dispatch, getState }, next, action ) => {
 	const result = next( action );

--- a/src/middlewares/socket-io/operator-load.js
+++ b/src/middlewares/socket-io/operator-load.js
@@ -21,7 +21,9 @@ import {
 	SET_USER_LOADS,
 	OPERATOR_OPEN_CHAT_FOR_CLIENTS,
 	REMOVE_USER,
-	SET_USER_OFFLINE
+	SET_USER_OFFLINE,
+	SET_OPERATOR_CAPACITY,
+	SET_OPERATOR_STATUS
 } from '../../operator/actions'
 import { REMOTE_ACTION_TYPE } from './broadcast'
 import {
@@ -87,6 +89,8 @@ const updateLoadMiddleware = ( { getState, dispatch } ) => next => action => {
 		case CLOSE_CHAT:
 		case SET_CHAT_OPERATOR:
 		case SET_CHATS_RECOVERED:
+		case SET_OPERATOR_CAPACITY:
+		case SET_OPERATOR_STATUS:
 		case REMOVE_USER:
 		case SET_USER_OFFLINE:
 			const result = next( action )

--- a/src/operator/actions.js
+++ b/src/operator/actions.js
@@ -27,6 +27,11 @@ export const OPERATOR_CHAT_TRANSFER = 'OPERATOR_CHAT_TRANSFER';
 export const OPERATOR_READY = 'OPERATOR_READY'
 export const SET_OPERATOR_CAPACITY = 'SET_OPERATOR_CAPACITY';
 export const SET_OPERATOR_STATUS = 'SET_OPERATOR_STATUS';
+export const SET_USER_OFFLINE = 'SET_USER_OFFLINE';
+
+export const setUserOffline = user => ( {
+	type: SET_USER_OFFLINE, user
+} )
 
 export const operatorTyping = ( id, user, text ) => (
 	{ type: OPERATOR_TYPING, id, user, text }

--- a/src/operator/selectors.js
+++ b/src/operator/selectors.js
@@ -8,8 +8,10 @@ import {
 	sort,
 	defaultTo,
 	values,
-	both
+	both,
+	equals
 } from 'ramda'
+import { asString } from '../util';
 import {
 	STATUS_AVAILABLE
 } from '../middlewares/socket-io'
@@ -65,3 +67,22 @@ export const haveAvailableCapacity = state => getAvailableCapacity( state ) > 0
 export const getSystemAcceptsCustomers = ( { operators: { system: { acceptsCustomers } } } ) => acceptsCustomers
 
 export const isSystemAcceptingCustomers = both( haveAvailableCapacity, getSystemAcceptsCustomers )
+
+export const getOperatorIdentity = ( id, state ) => view(
+	lensPath( [ 'operators', 'identities', asString( id ) ] ),
+	state
+)
+
+export const getOperatorOnline = ( id, state ) => view(
+	lensPath( [ 'operators', 'identities', asString( id ), 'online' ] ),
+	state
+)
+export const isOperatorStatusAvailable = ( id, state ) => equals(
+	view(
+		lensPath( [ 'operators', 'identities', asString( id ), 'status' ] ),
+		state
+	),
+	STATUS_AVAILABLE
+)
+export const isOperatorOnline = getOperatorOnline
+export const isOperatorAcceptingChats = ( id, state ) => isOperatorOnline( id, state ) && isOperatorStatusAvailable( id, state )

--- a/src/operator/selectors.js
+++ b/src/operator/selectors.js
@@ -29,8 +29,8 @@ export const getAvailableOperators = compose(
 		{ weight: weight( a ), capacity: a.capacity },
 		{ weight: weight( b ), capacity: b.capacity }
 	) ),
-	filter( ( { status, load, capacity } ) => {
-		if ( status !== STATUS_AVAILABLE ) {
+	filter( ( { status, load, capacity, online } ) => {
+		if ( !online || status !== STATUS_AVAILABLE ) {
 			return false;
 		}
 		return capacity - load > 0

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,5 @@
-import { v4 as uuid } from 'uuid'
+import { v4 as uuid } from 'uuid';
+import { compose, equals, invoker, when } from 'ramda';
 
 export const timestamp = () => (
 	Math.ceil( ( new Date() ).getTime() / 1000 )
@@ -11,3 +12,12 @@ export const makeEventMessage = ( text, session_id ) => ( {
 	session_id: session_id,
 	text
 } )
+
+const typeOf = v => typeof( v )
+export const asString = when(
+	compose(
+		equals( 'number' ),
+		typeOf
+	),
+	invoker( 0, 'toString' )
+)

--- a/test/integration/join-chat-test.js
+++ b/test/integration/join-chat-test.js
@@ -1,5 +1,6 @@
 import { ok, deepEqual } from 'assert'
 import util, { authenticators } from './util'
+import { STATUS_CLOSED } from 'chat-list/reducer'
 
 const debug = require( 'debug' )( 'happychat:test:join-chat' )
 
@@ -91,7 +92,7 @@ describe( 'Operator', () => {
 			} )
 			.then( () => requestState( operator ) )
 			.then( state => {
-				deepEqual( state.chatlist, {} )
+				deepEqual( state.chatlist['session-id'][0], STATUS_CLOSED )
 			} )
 		)
 	} )

--- a/test/unit/chat-list-reducer-test.js
+++ b/test/unit/chat-list-reducer-test.js
@@ -3,7 +3,8 @@ import reducer, {
 	STATUS_PENDING,
 	STATUS_MISSED,
 	STATUS_ABANDONED,
-	STATUS_ASSIGNED
+	STATUS_ASSIGNED,
+	STATUS_CLOSED
 } from 'chat-list/reducer'
 import {
 	// selectors
@@ -120,10 +121,10 @@ describe( 'ChatList reducer', () => {
 		}
 	) )
 
-	it( 'should remove closed chat', dispatchAction(
+	it( 'should set chat closed', dispatchAction(
 		closeChat( 'some-chat' ),
 		state => {
-			deepEqual( state, { chatlist: { 'other-chat': 'b' } } )
+			deepEqual( getChatStatus( 'some-chat', state ), STATUS_CLOSED )
 		},
 		{ 'some-chat': 'a', 'other-chat': 'b'}
 	) )
@@ -193,8 +194,8 @@ describe( 'ChatList reducer', () => {
 	it( 'should close chat when id is int', dispatchAction(
 		closeChat( 451 ),
 		state => {
-			deepEqual( state, { chatlist: {} } )
+			deepEqual( getChatStatus( 451, state ), STATUS_CLOSED )
 		},
-		{ 451: 'a chat' }
+		{ 451: [null, { id: '451' }, null, null, null ] }
 	) )
 } )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -12,6 +12,7 @@ import {
 	SET_CHAT_MISSED,
 	SET_CHATS_RECOVERED,
 	NOTIFY_CHAT_STATUS_CHANGED,
+	SET_CHAT_OPERATOR,
 	customerInboundMessage,
 	customerJoin,
 	customerDisconnect
@@ -359,5 +360,16 @@ describe( 'ChatList component', () => {
 
 			store.dispatch( customerDisconnect( chat, user ) )
 		} )
+	} )
+
+	it( 'should resasign closed chat to previous operator', done => {
+		chatlistWithState( {
+			operators: { identities: { opid: { id: 'opid', online: true, status: 'available' } } },
+			chatlist: { id: [ STATUS_CLOSED, { id: 'id' }, { id: 'opid' }, null, {} ] }
+		} )
+		watchForType( SET_CHAT_OPERATOR, () => {
+			done()
+		} )
+		store.dispatch( customerInboundMessage( { id: 'id' }, { id: '123', text: 'hello' } ) )
 	} )
 } )

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -51,26 +51,6 @@ describe( 'ChatList component', () => {
 		chatlistWithState()
 	} )
 
-	it( 'should notify when new chat has started', ( done ) => {
-		watchForTypeOnce( NOTIFY_CHAT_STATUS_CHANGED, ( { status, chat_id } ) => {
-			equal( status, 'pending' )
-			equal( chat_id, 'chat-id' )
-			watchForTypeOnce( NOTIFY_CHAT_STATUS_CHANGED, ( { status: status2, lastStatus } ) => {
-				equal( status2, 'assigning' )
-				equal( lastStatus, 'pending' )
-				done()
-			} )
-		} )
-		emitCustomerMessage()
-	} )
-
-	it( 'should request operator for chat', ( done ) => {
-		watchingMiddleware.watchForType( ASSIGN_CHAT, () => {
-			done()
-		} )
-		emitCustomerMessage()
-	} )
-
 	const connectOperator = ( operator, capacity = 1, status = 'available' ) => new Promise( resolve => {
 		// have an operator join
 		auth = () => Promise.resolve( merge( operator, { capacity, status } ) )
@@ -86,6 +66,27 @@ describe( 'ChatList component', () => {
 				} )
 			} )
 		} )
+	} )
+
+	it( 'should notify when new chat has started', ( done ) => {
+		watchForTypeOnce( NOTIFY_CHAT_STATUS_CHANGED, ( { status, chat_id } ) => {
+			equal( status, 'pending' )
+			equal( chat_id, 'chat-id' )
+			debug( 'first status check' )
+			watchForTypeOnce( NOTIFY_CHAT_STATUS_CHANGED, ( { status: status2, lastStatus } ) => {
+				equal( status2, 'assigning' )
+				equal( lastStatus, 'pending' )
+				done()
+			} )
+		} )
+		connectOperator( { id: 'op' } ).then( () => emitCustomerMessage() )
+	} )
+
+	it( 'should request operator for chat', ( done ) => {
+		watchingMiddleware.watchForType( ASSIGN_CHAT, () => {
+			done()
+		} )
+		connectOperator( { id: 'op' } ).then( () => emitCustomerMessage() )
 	} )
 
 	it( 'should move chat to active when operator found', () =>

--- a/test/unit/chat-list-test.js
+++ b/test/unit/chat-list-test.js
@@ -16,8 +16,9 @@ import {
 	customerJoin,
 	customerDisconnect
 } from 'chat-list/actions';
+import { STATUS_CLOSED } from 'chat-list/reducer'
 import { OPERATOR_CHAT_TRANSFER } from 'operator/actions'
-import { getChat, getChatStatus, getChatOperator } from 'chat-list/selectors'
+import { getChatStatus, getChatOperator } from 'chat-list/selectors'
 
 const debug = require( 'debug' )( 'happychat:chat-list:test' )
 
@@ -177,7 +178,7 @@ describe( 'ChatList component', () => {
 			watchingMiddleware.watchForType( CLOSE_CHAT, ( action ) => {
 				equal( action.operator.id, operator_id )
 				equal( action.chat_id, chat.id )
-				ok( ! getChat( chat.id, store.getState() ) )
+				equal( getChatStatus( chat.id, store.getState() ), STATUS_CLOSED )
 				done()
 			}, true )
 			client.emit( 'chat.close', 'the-id' )

--- a/test/unit/controller-test.js
+++ b/test/unit/controller-test.js
@@ -257,7 +257,7 @@ describe( 'Controller', () => {
 			client.on( 'init', () => {
 				client.emit( 'system.info', data => {
 					deepEqual( data.chats, [] )
-					deepEqual( data.operators, [ { id: 'operator', load: 0, capacity: 0 } ] )
+					deepEqual( data.operators, [ { id: 'operator', load: 0, capacity: 3, online: false } ] )
 					done()
 				} )
 			} ).connect()

--- a/test/unit/operator-reducer-test.js
+++ b/test/unit/operator-reducer-test.js
@@ -1,4 +1,4 @@
-import { equal } from 'assert'
+import { deepEqual, equal } from 'assert'
 import { setOperatorCapacity, setOperatorStatus } from 'operator/actions'
 import reducer from 'operator/reducer';
 import { createStore } from 'redux';
@@ -22,5 +22,11 @@ describe( 'Operator reducer', () => {
 		const store = createStore( reducer, { identities: { 'user-a': { capacity: 2 } } } )
 		store.dispatch( assoc( REMOTE_USER_KEY, { id: 'user-a' }, setOperatorCapacity( 'a' ) ) )
 		equal( store.getState().identities[ 'user-a' ].capacity, 2 )
+	} )
+
+	it( 'should update user', () => {
+		const store = createStore( reducer )
+		store.dispatch( { type: 'UPDATE_IDENTITY', user: { id: 1, name: 'hi' }, socket: {} } )
+		deepEqual( store.getState().identities, { 1: { id: 1, name: 'hi', capacity: 3, load: 0, online: false } } )
 	} )
 } )

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -9,7 +9,7 @@ import {
 	setAcceptsCustomers,
 	operatorChatJoin,
 	operatorChatClose,
-	REMOVE_USER,
+	SET_USER_OFFLINE,
 	OPERATOR_RECEIVE_TYPING,
 	OPERATOR_CHAT_LEAVE
 } from 'operator/actions'
@@ -75,8 +75,8 @@ describe( 'Operators', () => {
 		let op = { id: 'user-id', displayName: 'furiosa', avatarURL: 'url', priv: 'var', status: 'online', load: 1, capacity: 3 }
 		beforeEach( () => connectOperator( { socket, client }, op ) )
 
-		it( 'should remove user when last socket disconnects', ( done ) => {
-			watchForType( REMOVE_USER, action => {
+		it( 'should set user offline when last socket disconnects', ( done ) => {
+			watchForType( SET_USER_OFFLINE, action => {
 				equal( action.user.id, op.id )
 				done()
 			} )


### PR DESCRIPTION
After closing a chat it's common for the customer to send a final message. These
chats should go back to the operator that recently closed the chat.

To support this, tracking chats has changed:
- Closed chats remain in the chatlist with a status of "closed" and the assigned operator is still associated.
- When a chat becomes active again with a user message the chat is assigned to the same operator
- Closed chats are excluded from operator/system load calculations

Changes to operator state to support this feature:
- When the operator's final connection is closed  the operator identity is kept in the system
- An operator's offline/online status is tracked independently of their chosen chat status
- Offline operators are excluded when the queue is looking for an operator to assign

