### PR TITLE
Only uses operators that are online to count total available capacity

### DIFF
--- a/src/middlewares/socket-io/index.js
+++ b/src/middlewares/socket-io/index.js
@@ -24,8 +24,6 @@ import {
 
 const debug = require( 'debug' )( 'happychat:middleware:operators' )
 
-export const STATUS_AVAILABLE = 'available';
-
 const identityForUser = ( { id, displayName, avatarURL } ) => (
 	{ id, displayName, avatarURL }
 )

--- a/test/integration/abandon-test.js
+++ b/test/integration/abandon-test.js
@@ -1,6 +1,6 @@
 import { equal } from 'assert'
 import util, { authenticators } from './util'
-import { STATUS_AVAILABLE } from 'middlewares/socket-io'
+import { STATUS_AVAILABLE } from 'operator/selectors'
 
 const debug = require( 'debug' )( 'happychat:test:integration' )
 

--- a/test/unit/chat-list-selectors-test.js
+++ b/test/unit/chat-list-selectors-test.js
@@ -1,10 +1,10 @@
 import {
 	getChatMembers,
 	getOpenChatMembers
-} from '../../src/chat-list/selectors'
+} from 'chat-list/selectors'
 import {
 	STATUS_CLOSED,
-} from '../../src/chat-list/reducer';
+} from 'chat-list/reducer';
 import { deepEqual } from 'assert'
 
 describe( 'Chat List selectors', () => {

--- a/test/unit/operator-selectors-test.js
+++ b/test/unit/operator-selectors-test.js
@@ -1,0 +1,28 @@
+import { equal } from 'assert'
+import { getAvailableCapacity, STATUS_AVAILABLE } from 'operator/selectors'
+
+describe( 'Operator selectors', () => {
+	it( 'should calculate available capacity', () => {
+		equal(
+			getAvailableCapacity( { operators: { identities: {
+				a: { id: 'a', online: true, status: STATUS_AVAILABLE, load: 1, capacity: 4 },
+				b: { id: 'b', online: true, status: STATUS_AVAILABLE, load: 2, capacity: 3 },
+			} } } ),
+			4
+		)
+
+		equal(
+			getAvailableCapacity( { operators: { identities: {
+				a: { id: 'a', online: false, status: STATUS_AVAILABLE, load: 1, capacity: 4 },
+			} } } ),
+			0
+		)
+
+		equal(
+			getAvailableCapacity( { operators: { identities: {
+				a: { id: 'a', online: false, status: 'other', load: 1, capacity: 4 },
+			} } } ),
+			0
+		)
+	} )
+} )

--- a/test/unit/operator-selectors-test.js
+++ b/test/unit/operator-selectors-test.js
@@ -3,6 +3,7 @@ import { getAvailableCapacity, STATUS_AVAILABLE } from 'operator/selectors'
 
 describe( 'Operator selectors', () => {
 	it( 'should calculate available capacity', () => {
+		// total of all operators online: true and status == STATUS_AVAILABLE
 		equal(
 			getAvailableCapacity( { operators: { identities: {
 				a: { id: 'a', online: true, status: STATUS_AVAILABLE, load: 1, capacity: 4 },
@@ -11,6 +12,7 @@ describe( 'Operator selectors', () => {
 			4
 		)
 
+		// exludes operators with online: false
 		equal(
 			getAvailableCapacity( { operators: { identities: {
 				a: { id: 'a', online: false, status: STATUS_AVAILABLE, load: 1, capacity: 4 },
@@ -18,6 +20,7 @@ describe( 'Operator selectors', () => {
 			0
 		)
 
+		// exclude operators with status != STATUS_AVAILABLE
 		equal(
 			getAvailableCapacity( { operators: { identities: {
 				a: { id: 'a', online: false, status: 'other', load: 1, capacity: 4 },


### PR DESCRIPTION
Operator identities previously were removed from the system when they went.
Now the identity is flagged offline.

Fixes an issue where the system would get stuck in an assignment loop due to
incorrectly thinking there was available capacity but would be unable to assign
a chat.