### PR TITLE
Ignores chat disconnects when chat status already closed

### DIFF
--- a/src/state/middlewares/socket-io/chatlist.js
+++ b/src/state/middlewares/socket-io/chatlist.js
@@ -248,6 +248,11 @@ export default ( { io, timeout = 1000, customerDisconnectTimeout = 90000, custom
 			debug( 'Customer disconnected without starting chat', chat.id )
 			return;
 		}
+
+		if ( isChatStatusClosed( chat.id, store.getState() ) ) {
+			debug( 'Customer disconnected after chat closed' )
+			return
+		}
 		store.dispatch( setChatCustomerDisconnect( chat.id ) )
 		store.dispatch( delayAction( customerLeft( chat.id ), customerDisconnectMessageTimeout ) )
 		store.dispatch( delayAction( autocloseChat( chat.id ), customerDisconnectTimeout ) )


### PR DESCRIPTION
This prevents closed chats from becoming active again when the customer closes
their browser window after having their chat closed.