### PR TITLE
Updates operator load after a chat has been auto-closed by the system

### DIFF
--- a/src/state/middlewares/socket-io/operator-load.js
+++ b/src/state/middlewares/socket-io/operator-load.js
@@ -17,7 +17,8 @@ import {
 	SET_USER_OFFLINE,
 	SET_OPERATOR_CAPACITY,
 	SET_OPERATOR_STATUS,
-	REMOTE_ACTION_TYPE
+	REMOTE_ACTION_TYPE,
+	AUTOCLOSE_CHAT
 } from '../../action-types'
 import {
 	getOpenChatMembers,
@@ -101,6 +102,7 @@ const updateLoadMiddleware = ( { getState, dispatch } ) => next => action => {
 		case SET_OPERATOR_STATUS:
 		case REMOVE_USER:
 		case SET_USER_OFFLINE:
+		case AUTOCLOSE_CHAT:
 			const result = next( action )
 			dispatch( setUserLoads( reducer( getState() ) ) )
 			return result;


### PR DESCRIPTION
Fixes an issue where operator loads don't go down when a chat is closed after
the user has been disconnected.