### PR TITLE
Add eslint as a local dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
+    "babel-eslint": "^6.0.0-beta.5",
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
+    "eslint": "3.8.1",
     "isparta": "^4.0.0",
     "mocha": "^2.4.5",
     "mocha-junit-reporter": "^1.12.0",


### PR DESCRIPTION
What are your thoughts about using `eslint` as a local package instead of depending on a global version? As I see it now, having it as a local dependency makes easier to switch between projects without conflicts, and also helps in documenting all dependencies.

I don't mind the specific versions, just choose what calypso was using - I'll be happy to change them to others if there is a better fit.