### PR TITLE
Removes break statement that prevents code from running

### DIFF
--- a/src/state/middlewares/socket-io/operator-load.js
+++ b/src/state/middlewares/socket-io/operator-load.js
@@ -140,7 +140,6 @@ const chatStatusNotifier = ( { getState, dispatch } ) => next => action => {
 			break;
 		// select chats for operator action.operator_id
 		case SET_OPERATOR_CHATS_ABANDONED:
-			break;
 			chat_ids = map(
 				view( lensProp( 'id' ) ),
 				getChatsForOperator( action.operator_id, getState() )


### PR DESCRIPTION
Chats were not being notified of their abandoned status. This fixes that issue.