### PR TITLE
Removes chatlist from serialized data

### DIFF
--- a/src/state/chatlist/reducer.js
+++ b/src/state/chatlist/reducer.js
@@ -34,7 +34,8 @@ import {
 	OPERATOR_CHAT_LEAVE,
 	OPERATOR_CHAT_JOIN,
 	UPDATE_CHAT,
-	REMOVE_CHAT
+	REMOVE_CHAT,
+	SERIALIZE,
 } from '../action-types'
 
 export const STATUS_NEW = 'new'
@@ -120,6 +121,8 @@ const whereStatusIsNot = status => compose(
 
 export default ( state = {}, action ) => {
 	switch ( action.type ) {
+		case SERIALIZE:
+			return {}
 		case REMOVE_CHAT:
 			return dissoc( asString( action.id ), state )
 		case AUTOCLOSE_CHAT:


### PR DESCRIPTION
This data is mostly used to reconnect customers to previous
operators after a system reboot.

This information can be provided in real time.