### PR TITLE
Limits rate of state broadcasts

### DIFF
--- a/src/state/index.js
+++ b/src/state/index.js
@@ -9,6 +9,7 @@ import agentMiddleware from './middlewares/socket-io/agents'
 import controllerMiddleware from './middlewares/socket-io/controller'
 import operatorLoadMiddleware from './middlewares/socket-io/operator-load'
 import canRemoteDispatch from './operator/canRemoteDispatch'
+import shouldBroadcastStateChange from './should-broadcast'
 import { DESERIALIZE, SERIALIZE } from './action-types'
 
 const debug = require( 'debug' )( 'happychat:store' )
@@ -41,7 +42,7 @@ export default ( { io, customerAuth, operatorAuth, agentAuth, messageMiddlewares
 				customerDisconnectTimeout: timeout,
 				customerDisconnectMessageTimeout: timeout
 			}, customerAuth, messageMiddlewares ),
-			broadcastMiddleware( io.of( '/operator' ), canRemoteDispatch ),
+			broadcastMiddleware( io.of( '/operator' ), { canRemoteDispatch, shouldBroadcastStateChange } ),
 			...operatorLoadMiddleware,
 	)
 }

--- a/src/state/middlewares/socket-io/broadcast.js
+++ b/src/state/middlewares/socket-io/broadcast.js
@@ -1,6 +1,6 @@
 import jsondiff from 'simperium-jsondiff'
 import { v4 as uuid } from 'uuid'
-import debounce from 'lodash/debounce'
+import { debounce } from 'lodash'
 import { OPERATOR_READY, REMOTE_ACTION_TYPE } from '../../action-types'
 import { isEmpty } from 'ramda'
 import { selectSocketIdentity } from '../../operator/selectors'

--- a/src/state/should-broadcast.js
+++ b/src/state/should-broadcast.js
@@ -1,0 +1,17 @@
+import {
+	OPERATOR_TYPING,
+	OPERATOR_RECEIVE_TYPING,
+	CUSTOMER_TYPING,
+	CUSTOMER_RECEIVE_TYPING
+} from './action-types'
+
+export default ( { type } ) => {
+	switch ( type ) {
+		case OPERATOR_TYPING:
+		case OPERATOR_RECEIVE_TYPING:
+		case CUSTOMER_TYPING:
+		case CUSTOMER_RECEIVE_TYPING:
+			return false
+	}
+	return true
+}

--- a/test/integration/join-chat-test.js
+++ b/test/integration/join-chat-test.js
@@ -54,6 +54,12 @@ describe( 'Operator', () => {
 		} )
 	} )
 
+	const waitForUpdate = client => new Promise( ( resolve ) => {
+		client.once( 'broadcast.update', ( version, nextVersion, patch ) => {
+			resolve( patch )
+		} )
+	} )
+
 	beforeEach( () => {
 		service = util( authenticators( mockUser, opUser, {} ) )
 		service.start()
@@ -86,11 +92,13 @@ describe( 'Operator', () => {
 			} )
 		)
 
-		it( 'should close chat', () => requestState( operator )
+		it( 'should close chat', () => waitForUpdate( operator )
+			.then( () => requestState( operator ) )
 			.then( state => {
 				ok( state.chatlist['session-id'] )
 				closeChat( operator, mockUser.session_id )
 			} )
+			.then( () => waitForUpdate( operator ) )
 			.then( () => requestState( operator ) )
 			.then( state => {
 				deepEqual( state.chatlist['session-id'][0], STATUS_CLOSED )

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -66,7 +66,7 @@ describe( 'Operators', () => {
 		) )
 	} )
 
-	it.only( 'should send current state to operator', done => {
+	it( 'should send current state to operator', done => {
 		const connection = server.newClient( socketid )
 		connection.client.once( 'broadcast.update', ( lastVersion, nextVersion ) => {
 			process.nextTick( () => {

--- a/test/unit/operator-test.js
+++ b/test/unit/operator-test.js
@@ -66,12 +66,16 @@ describe( 'Operators', () => {
 		) )
 	} )
 
-	it( 'should send current state to operator', done => {
+	it.only( 'should send current state to operator', done => {
 		const connection = server.newClient( socketid )
-		connection.client.on( 'broadcast.state', ( version, state ) => {
-			ok( version )
-			deepEqual( state, store.getState() )
-			done()
+		connection.client.once( 'broadcast.update', ( lastVersion, nextVersion ) => {
+			process.nextTick( () => {
+				connection.client.emit( 'broadcast.state', ( version, state ) => {
+					equal( version, nextVersion )
+					deepEqual( state, store.getState() )
+					done()
+				} )
+			} )
 		} )
 		return connectOperator( connection )
 	} )


### PR DESCRIPTION
Instead of running on every dispatch, uses `lodash/debounce` to limit haw often it performs diffs and sends broadcasts.