### PR TITLE
Serializes assigned chats

### DIFF
--- a/src/state/chatlist/reducer.js
+++ b/src/state/chatlist/reducer.js
@@ -15,6 +15,7 @@ import {
 	not,
 	equals,
 	both,
+	filter
 } from 'ramda'
 import { asString } from '../util'
 import {
@@ -119,10 +120,15 @@ const whereStatusIsNot = status => compose(
 	statusView
 )
 
+export const onlyOpen = filter( compose(
+	equals( STATUS_ASSIGNED ),
+	statusView,
+) )
+
 export default ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SERIALIZE:
-			return {}
+			return onlyOpen( state )
 		case REMOVE_CHAT:
 			return dissoc( asString( action.id ), state )
 		case AUTOCLOSE_CHAT:

--- a/test/unit/chat-list-reducer-test.js
+++ b/test/unit/chat-list-reducer-test.js
@@ -31,6 +31,9 @@ import {
 	operatorChatLeave,
 	operatorChatJoin,
 } from 'state/operator/actions'
+import {
+	serializeAction
+} from 'state'
 
 const debug = require( 'debug' )( 'happychat:test' )
 
@@ -199,6 +202,21 @@ describe( 'ChatList reducer', () => {
 			2: [ STATUS_ABANDONED, '2', { id: 'op-id' }, 2, {} ],
 			3: [ STATUS_ABANDONED, '3', { id: 'op-id' }, 3, {} ],
 			4: [ STATUS_PENDING, '4', { id: 'other' }, 4, {} ]
+		}	) )
+
+	it( 'should serialize only assigned chats', dispatchAction(
+			serializeAction(),
+			state => {
+				deepEqual( state, { chatlist: {
+					a: [ STATUS_ASSIGNED, 'a', { id: 'op-id' }, 1, {} ],
+					4: [ STATUS_ASSIGNED, '4', { id: 'other' }, 4, {} ]
+				} } )
+			},
+		{
+			a: [ STATUS_ASSIGNED, 'a', { id: 'op-id' }, 1, {} ],
+			2: [ STATUS_ABANDONED, '2', { id: 'op-id' }, 2, {} ],
+			3: [ STATUS_ABANDONED, '3', { id: 'op-id' }, 3, {} ],
+			4: [ STATUS_ASSIGNED, '4', { id: 'other' }, 4, {} ]
 		}	) )
 
 	it( 'should close chat when id is int', dispatchAction(


### PR DESCRIPTION
Includes assigned chats when serializing the chatlist reducer.

This prevents customers from switching between operators between reboots.