### PR TITLE
Fixes blocked chat assignments between locales

### DIFF
--- a/src/state/chatlist/selectors.js
+++ b/src/state/chatlist/selectors.js
@@ -223,11 +223,20 @@ export const getChatGroups = ( chat_id, state ) => compose(
 	selectChat( chat_id ),
 )( state )
 
+const findPending = filter( compose(
+	anyPass( map( equals, [ STATUS_PENDING ] ) ),
+	statusView
+) )
+
 const getAssignableChats = compose(
-	filter( compose(
-		anyPass( map( equals, [ STATUS_PENDING ] ) ),
-		statusView
-	) ),
+	findPending,
+	values,
+	selectChatlist
+)
+
+export const getAllAssignableChats = compose(
+	mapToChat,
+	findPending,
 	values,
 	selectChatlist
 )

--- a/src/state/middlewares/socket-io/chatlist.js
+++ b/src/state/middlewares/socket-io/chatlist.js
@@ -68,6 +68,7 @@ import {
 	getOpenChatsForOperator,
 	getChatStatus,
 	getChatLocale,
+	getAllAssignableChats,
 	getNextAssignableChat,
 	getOperatorAbandonedChats,
 	haveAssignableChat,
@@ -515,20 +516,18 @@ export default ( { io, timeout = 1000, customerDisconnectTimeout = 90000, custom
 			return
 		}
 
-		const chat = getNextAssignableChat( store.getState() )
-		const locale = getChatLocale( chat.id, store.getState() )
-		const groups = getChatGroups( chat.id, store.getState() )
+		const chats = getAllAssignableChats( store.getState() )
+		for ( const chat of chats ) {
+			const locale = getChatLocale( chat.id, store.getState() )
+			const groups = getChatGroups( chat.id, store.getState() )
+			debug( 'checking capacity to assign chat', locale, groups )
 
-		debug( 'checking capacity to assign chat', locale, groups )
-
-		if ( ! haveAvailableCapacity( locale, groups, store.getState() ) ) {
-			// TODO: Set chat as missed and let other chats through
-			log( 'no capacity to assign chat',
-				chat.id, locale, groups )
-			return
+			if ( haveAvailableCapacity( locale, groups, store.getState() ) ) {
+				// TODO: Set chat as missed and let other chats through
+				return store.dispatch( assignChat( chat ) )
+			}
+			log( 'no capacity to assign chat', chat.id, locale, groups )
 		}
-
-		store.dispatch( assignChat( chat ) )
 	}
 
 	const handleNotifiSystemStatusChange = () => {

--- a/src/state/middlewares/socket-io/chatlist.js
+++ b/src/state/middlewares/socket-io/chatlist.js
@@ -523,7 +523,6 @@ export default ( { io, timeout = 1000, customerDisconnectTimeout = 90000, custom
 			debug( 'checking capacity to assign chat', locale, groups )
 
 			if ( haveAvailableCapacity( locale, groups, store.getState() ) ) {
-				// TODO: Set chat as missed and let other chats through
 				return store.dispatch( assignChat( chat ) )
 			}
 			log( 'no capacity to assign chat', chat.id, locale, groups )

--- a/test/unit/chatlist-assignment-test.js
+++ b/test/unit/chatlist-assignment-test.js
@@ -1,4 +1,4 @@
-import { equal } from 'assert'
+import { equal, deepEqual } from 'assert'
 
 import chatlistMiddleware from 'state/middlewares/socket-io/chatlist'
 import mockio from '../mock-io'
@@ -87,6 +87,24 @@ describe( 'Chatlist Assignment', () => {
 		}
 	}
 
+	const blockedState = {
+		locales: { defaultLocale: 'en', supported: [ 'en', 'cz' ], memberships: {
+			en: { op1: { capacity: 3, load: 0, active: true } },
+			cz: { op2: { capacity: 1, load: 1, active: true } }
+		} },
+		operators: { identities: {
+			op1: { id: 'op1', status: STATUS_AVAILABLE, online: true },
+			op2: { id: 'op2', status: STATUS_AVAILABLE, online: true }
+		} },
+		chatlist: {
+			chat_cz: [STATUS_PENDING, { id: 'chat_cz'}, null, 1, {}, 'cz'],
+			chat_en: [STATUS_PENDING, { id: 'chat_en'}, null, 2, {}, 'en']
+		},
+		groups: {
+			[ DEFAULT_GROUP_ID ]: { members: { op1: true, op2: true } },
+		}
+	}
+
 	it( 'should assign next chat', () => dispatchAction(
 		assignNextChat(),
 		ptbrState
@@ -123,5 +141,12 @@ describe( 'Chatlist Assignment', () => {
 		ptbrState
 	).then( action => {
 		equal( action.type, SET_CHAT_MISSED )
+	} ) )
+
+	it( 'should assign chat if earlier chat is unassigned', () => dispatchAction(
+		assignNextChat(),
+		blockedState
+	).then( action => {
+		deepEqual( action, assignChat( { id: 'chat_en'} ) )
 	} ) )
 } )

--- a/test/unit/chatlist-assignment-test.js
+++ b/test/unit/chatlist-assignment-test.js
@@ -98,7 +98,8 @@ describe( 'Chatlist Assignment', () => {
 		} },
 		chatlist: {
 			chat_cz: [STATUS_PENDING, { id: 'chat_cz'}, null, 1, {}, 'cz'],
-			chat_en: [STATUS_PENDING, { id: 'chat_en'}, null, 2, {}, 'en']
+			chat_en: [STATUS_PENDING, { id: 'chat_en'}, null, 2, {}, 'en'],
+			chat_en2: [STATUS_PENDING, { id: 'chat_en2'}, null, 3, {}, 'en']
 		},
 		groups: {
 			[ DEFAULT_GROUP_ID ]: { members: { op1: true, op2: true } },


### PR DESCRIPTION
If a locale has a chat that fails to get assigned, it will block other locale chat assignments until the chat is assigned or disconnected.

The assignment action now loops through all pending chats until it finds its first assignable chat.