### PR TITLE
Update operator availability as unavailable upon going offline

### DIFF
--- a/src/state/operator/constants.js
+++ b/src/state/operator/constants.js
@@ -1,5 +1,0 @@
-// This should be synced with the front-end side
-export const OPERATOR_STATUS_UNAVAILABLE = 'unavailable';
-export const OPERATOR_STATUS_AVAILABLE = 'available';
-export const OPERATOR_STATUS_BUSY = 'busy';
-export const OPERATOR_STATUS_UNKNOWN = 'unknown';

--- a/src/state/operator/constants.js
+++ b/src/state/operator/constants.js
@@ -1,0 +1,5 @@
+// This should be synced with the front-end side
+export const OPERATOR_STATUS_UNAVAILABLE = 'unavailable';
+export const OPERATOR_STATUS_AVAILABLE = 'available';
+export const OPERATOR_STATUS_BUSY = 'busy';
+export const OPERATOR_STATUS_UNKNOWN = 'unknown';

--- a/src/state/operator/reducer.js
+++ b/src/state/operator/reducer.js
@@ -28,6 +28,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from '../action-types'
+import { OPERATOR_STATUS_UNAVAILABLE } from './constants';
 
 // Reducers
 const user_sockets = ( state = {}, action ) => {
@@ -60,7 +61,7 @@ const identity = ( state = { online: false }, action ) => {
 		case SET_OPERATOR_STATUS:
 			return merge( state, { status: action.status, online: true } )
 		case SET_USER_OFFLINE:
-			return merge( state, { online: false } )
+			return merge( state, { status: OPERATOR_STATUS_UNAVAILABLE, online: false } );
 	}
 	return state
 }

--- a/src/state/operator/reducer.js
+++ b/src/state/operator/reducer.js
@@ -28,7 +28,6 @@ import {
 	SERIALIZE,
 	DESERIALIZE
 } from '../action-types'
-import { OPERATOR_STATUS_UNAVAILABLE } from './constants';
 
 // Reducers
 const user_sockets = ( state = {}, action ) => {

--- a/src/state/operator/reducer.js
+++ b/src/state/operator/reducer.js
@@ -61,7 +61,7 @@ const identity = ( state = { online: false }, action ) => {
 		case SET_OPERATOR_STATUS:
 			return merge( state, { status: action.status, online: true } )
 		case SET_USER_OFFLINE:
-			return merge( state, { status: OPERATOR_STATUS_UNAVAILABLE, online: false } );
+			return merge( state, { status: 'unavailable', online: false } );
 	}
 	return state
 }

--- a/test/unit/operator-reducer-test.js
+++ b/test/unit/operator-reducer-test.js
@@ -1,5 +1,9 @@
 import { deepEqual, equal } from 'assert'
-import { setOperatorCapacity, setOperatorStatus } from 'state/operator/actions'
+import {
+	setOperatorCapacity,
+	setOperatorStatus,
+	setUserOffline,
+} from 'state/operator/actions'
 import reducer from 'state/operator/reducer';
 import { createStore } from 'redux';
 import { REMOTE_USER_KEY } from 'state/middlewares/socket-io/broadcast'
@@ -34,4 +38,18 @@ describe( 'Operator reducer', () => {
 		deepEqual( store.getState().sockets, {} );
 		deepEqual( store.getState().user_sockets, {} );
 	} )
+
+	it( 'should set operator offline and unavailable', () => {
+		const store = createStore( reducer, {
+			identities: {
+				'user-a': {
+					status: 'any',
+					online: true,
+				}
+			}
+		} );
+		store.dispatch( setUserOffline( { id: 'user-a' } ) );
+		equal( store.getState().identities[ 'user-a' ].status, 'unavailable' );
+		equal( store.getState().identities[ 'user-a' ].online, false );
+	} );
 } )


### PR DESCRIPTION
## Summary
The action `SET_USER_OFFLINE` should not only set `online` as false but also set `status` as `unavailable`.

## Test Plan
Run `npm test`



