### PR TITLE
Fixes bug in chat status notifier

### DIFF
--- a/src/state/middlewares/socket-io/customer.js
+++ b/src/state/middlewares/socket-io/customer.js
@@ -175,8 +175,8 @@ export default ( { io, timeout = 1000 }, customerAuth, messageFilter ) => store 
 				handleNotifiSystemStatusChange( action );
 				break;
 			case NOTIFY_CHAT_STATUS_CHANGED:
-				const status = getChatStatus( action.chatID, store.getState() );
-				io.to( customerRoom( action.chatID ) ).emit( 'status', status );
+				const status = getChatStatus( action.chat_id, store.getState() );
+				io.to( customerRoom( action.chat_id ) ).emit( 'status', status );
 				break;
 			case CUSTOMER_RECEIVE_TYPING:
 				handleCustomerReceiveTyping( action );

--- a/test/unit/state/middleware/socket-io/customer-test.js
+++ b/test/unit/state/middleware/socket-io/customer-test.js
@@ -1,0 +1,46 @@
+import { equal } from 'assert';
+import customer from 'state/middlewares/socket-io/customer';
+import { run } from 'message-filter';
+import { EventEmitter } from 'events';
+
+import { notifyChatStatusChanged } from 'state/chatlist/actions';
+import { getChatStatus } from 'state/chatlist/selectors';
+import { state, newChatID } from '../../mock-state';
+
+/**
+ * Mock customer auth interface
+ * @param { Object } socket - socket.io client connection
+ * @returns { Promise } resolves customer identity for the connecting socket
+ */
+const auth = () => new Promise( resolve => {
+	resolve();
+} );
+
+const messageFilter = ( ... args ) => run( [] )( ... args );
+const noop = () => {};
+
+describe( 'state/middlewares/socket-io/customer', () => {
+	/**
+	 * Ensures that Socket.IO clients rececive a 'status' event for a customer's
+	 * chat room when `notifyChatStatusChanged` is emitted.
+	 */
+	it( 'handles NOTIFY_CHAT_STATUS_CHANGED', done => {
+		// sets up a mock Socket.IO server interface
+		const io = new EventEmitter();
+		// the customer's chat room will receive an event so all potentially connected clients
+		// are set to the same status
+		io.to = room => {
+			equal( room, `customer/${ newChatID }` );
+			// mock Socket.IO room interface
+			return {
+				emit: ( event, status ) => {
+					equal( event, 'status' );
+					equal( status, getChatStatus( newChatID, state ) );
+					done();
+				}
+			};
+		};
+		const middleware = customer( { io }, auth, messageFilter )( { getState: () => state } );
+		middleware( noop )( notifyChatStatusChanged( newChatID ) );
+	} );
+} );


### PR DESCRIPTION
Customer clients were not receiving chat status updates from the service.

The `socket-io/customer` middleware was using `.chatID` but the action puts the id in `.chat_id`.