### PR TITLE
Reports invalid values in the chatlist reducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "socket.io": "^1.0"
   },
   "dependencies": {
+    "is-my-json-valid": "^2.16.0",
     "lodash": "^4.11.1",
     "ramda": "^0.22.1",
     "redux": "^3.5.2",

--- a/src/state/chatlist/schema.js
+++ b/src/state/chatlist/schema.js
@@ -1,0 +1,57 @@
+/**
+ * Schemas for `chatlist` reducer
+ */
+
+export const chatStatus = { type: 'string' };
+export const chatSession = {
+	type: 'object',
+	required: [ 'user_id', 'id' ],
+	properties: {
+		'user_id': { type: [ 'number', 'string' ] },
+		'id': { type: [ 'number', 'string' ] },
+		'username': { type: 'string' },
+		'name': { type: 'string' },
+		'picture': { type: 'string' },
+		'locale': { type: 'string' }
+	},
+	additionalProperties: true,
+};
+export const assignedOperator = {
+	type: [ 'null', 'object' ],
+	required: [ 'id', 'status', 'capacity', 'load', 'active' ],
+	properties: {
+		online: { type: 'boolean' },
+		id: { type: [ 'number', 'string' ] },
+		requestingChat: { type: 'boolean' },
+		username: { type: 'string' },
+		displayName: { type: 'string' },
+		picture: { type: 'string' },
+		capacity: { type: 'number' },
+		load: { type: 'number' },
+		active: { type: 'boolean' },
+	},
+	additionalProperties: true,
+};
+export const timestamp = { type: 'number' };
+
+// Operator list is a map of operator_id: bool of operators in the chat
+export const operatorList = { type: 'object', additionalProperties: { type: 'boolean' } };
+
+export const locale = { type: 'string' }
+export const groups = { type: [ 'null', 'array'] }
+
+// A chat is a tuple (using a JS array)
+export const chat = {
+	required: true,
+	type: 'array',
+	items: [
+		chatStatus,
+		chatSession,
+		assignedOperator,
+		timestamp,
+		operatorList,
+		locale,
+		groups,
+	],
+	additionalItems: false,
+}

--- a/src/state/validate.js
+++ b/src/state/validate.js
@@ -1,0 +1,28 @@
+import debug from 'debug';
+
+const log = debug( 'happychat:state' );
+
+/**
+ * Higher order function to wrap around a reducer. Validates the reducer each
+ * time it's run, logging an error if the state *becomes* invalid when the reducer is run.
+ * @param {string} reference A unique name to refer to this validation
+ * @param {function} validator The schema to validate the current reducer state against
+ * @param {function} reducer The reducer to be wrapped
+ * @returns {function} The wrapped reducer function
+ */
+export const validateReducer = ( reference, validator, reducer ) => ( state, action ) => {
+	const validBefore = validator( state );
+	const newState = reducer( state, action );
+	if ( typeof state === 'undefined' || validBefore ) {
+		// Only check the validity after reducer if this is the first
+		// time the reducer was run or the state was valid before
+		const validAfter = validator( newState );
+		if ( ! validAfter ) {
+			log( 'State became invalid: ', reference,
+				'\n -- Validation errors --\n', validator.errors,
+				'\n -- Action -- \n', action,
+				'\n -- New state -- \n', newState );
+		}
+	}
+	return newState;
+}


### PR DESCRIPTION
Adds a schema for the chatlist reducer, then runs that validation each time the reducer is called. If the state was valid but becomes invalid when the reducer is run, the offending action is reported to the console.

Here's an example validation error:
```
-- Validation errors --
 [ { field: 'data["2"].displayName',
    message: 'is the wrong type',
    value: 1234,
    type: 'string' } ]
```